### PR TITLE
chore: scaffold blp monorepo structure

### DIFF
--- a/blp/.editorconfig
+++ b/blp/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/blp/.gitattributes
+++ b/blp/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/blp/.github/workflows/ci-connectors.yml
+++ b/blp/.github/workflows/ci-connectors.yml
@@ -1,0 +1,9 @@
+name: Placeholder workflow
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Workflow $f placeholder"

--- a/blp/.github/workflows/ci-core.yml
+++ b/blp/.github/workflows/ci-core.yml
@@ -1,0 +1,9 @@
+name: Placeholder workflow
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Workflow $f placeholder"

--- a/blp/.github/workflows/ci-rules.yml
+++ b/blp/.github/workflows/ci-rules.yml
@@ -1,0 +1,9 @@
+name: Placeholder workflow
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Workflow $f placeholder"

--- a/blp/.gitignore
+++ b/blp/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+.env*
+dist
+coverage
+__pycache__
+*.pyc
+.DS_Store
+*.log
+.idea
+.vscode
+*.tar.gz

--- a/blp/README.md
+++ b/blp/README.md
@@ -1,0 +1,5 @@
+# Broker-Lender Platform Monorepo Scaffold
+
+This repository contains the initial scaffolding for the Broker-Lender Platform (BLP) MVP. It provides structured directories, configuration stubs, and placeholder documentation for the database, backend services, rules engine, policy bundles, connectors, and workflow workers.
+
+The generated structure follows the architecture described in the specification, enabling further implementation of PostgreSQL with Row-Level Security, NestJS-based APIs, FastAPI rules engine, Auth0/OPA authorization, connector services, and Temporal workflows.

--- a/blp/apps/connectors/aus-gateway/src/mappers.ts
+++ b/blp/apps/connectors/aus-gateway/src/mappers.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/connectors/aus-gateway/src/server.ts
+++ b/blp/apps/connectors/aus-gateway/src/server.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/connectors/aus-gateway/src/service.ts
+++ b/blp/apps/connectors/aus-gateway/src/service.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/connectors/credit/src/mappers.ts
+++ b/blp/apps/connectors/credit/src/mappers.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/connectors/credit/src/server.ts
+++ b/blp/apps/connectors/credit/src/server.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/connectors/credit/src/service.ts
+++ b/blp/apps/connectors/credit/src/service.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/connectors/esign/src/server.ts
+++ b/blp/apps/connectors/esign/src/server.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/connectors/esign/src/service.ts
+++ b/blp/apps/connectors/esign/src/service.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/connectors/esign/src/webhook.controller.ts
+++ b/blp/apps/connectors/esign/src/webhook.controller.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/connectors/ppe-adapter/src/mappers.ts
+++ b/blp/apps/connectors/ppe-adapter/src/mappers.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/connectors/ppe-adapter/src/server.ts
+++ b/blp/apps/connectors/ppe-adapter/src/server.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/connectors/ppe-adapter/src/service.ts
+++ b/blp/apps/connectors/ppe-adapter/src/service.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/connectors/ppe-adapter/test/contract.pact.ts
+++ b/blp/apps/connectors/ppe-adapter/test/contract.pact.ts
@@ -1,0 +1,1 @@
+// Placeholder contract test.

--- a/blp/apps/core-api/src/app.module.ts
+++ b/blp/apps/core-api/src/app.module.ts
@@ -1,0 +1,1 @@
+// Placeholder module definition.

--- a/blp/apps/core-api/src/aus/aus.controller.ts
+++ b/blp/apps/core-api/src/aus/aus.controller.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/aus/aus.module.ts
+++ b/blp/apps/core-api/src/aus/aus.module.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/aus/aus.service.ts
+++ b/blp/apps/core-api/src/aus/aus.service.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/auth/auth.controller.ts
+++ b/blp/apps/core-api/src/auth/auth.controller.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/auth/auth.module.ts
+++ b/blp/apps/core-api/src/auth/auth.module.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/auth/auth.service.ts
+++ b/blp/apps/core-api/src/auth/auth.service.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/common/guards/index.ts
+++ b/blp/apps/core-api/src/common/guards/index.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/common/interceptors/index.ts
+++ b/blp/apps/core-api/src/common/interceptors/index.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/common/pipes/index.ts
+++ b/blp/apps/core-api/src/common/pipes/index.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/conditions/conditions.module.ts
+++ b/blp/apps/core-api/src/conditions/conditions.module.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/conditions/conditions.service.ts
+++ b/blp/apps/core-api/src/conditions/conditions.service.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/config/index.ts
+++ b/blp/apps/core-api/src/config/index.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/credit/credit.controller.ts
+++ b/blp/apps/core-api/src/credit/credit.controller.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/credit/credit.module.ts
+++ b/blp/apps/core-api/src/credit/credit.module.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/credit/credit.service.ts
+++ b/blp/apps/core-api/src/credit/credit.service.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/disclosures/disclosures.module.ts
+++ b/blp/apps/core-api/src/disclosures/disclosures.module.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/disclosures/disclosures.service.ts
+++ b/blp/apps/core-api/src/disclosures/disclosures.service.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/documents/documents.module.ts
+++ b/blp/apps/core-api/src/documents/documents.module.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/documents/documents.service.ts
+++ b/blp/apps/core-api/src/documents/documents.service.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/events/events.module.ts
+++ b/blp/apps/core-api/src/events/events.module.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/events/producer.service.ts
+++ b/blp/apps/core-api/src/events/producer.service.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/health/health.controller.ts
+++ b/blp/apps/core-api/src/health/health.controller.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/loans/loans.controller.ts
+++ b/blp/apps/core-api/src/loans/loans.controller.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/loans/loans.module.ts
+++ b/blp/apps/core-api/src/loans/loans.module.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/loans/loans.service.ts
+++ b/blp/apps/core-api/src/loans/loans.service.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/main.ts
+++ b/blp/apps/core-api/src/main.ts
@@ -1,0 +1,1 @@
+// Placeholder entrypoint for NestJS application.

--- a/blp/apps/core-api/src/opa/opa.module.ts
+++ b/blp/apps/core-api/src/opa/opa.module.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/opa/opa.service.ts
+++ b/blp/apps/core-api/src/opa/opa.service.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/pricing/pricing.controller.ts
+++ b/blp/apps/core-api/src/pricing/pricing.controller.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/pricing/pricing.module.ts
+++ b/blp/apps/core-api/src/pricing/pricing.module.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/pricing/pricing.service.ts
+++ b/blp/apps/core-api/src/pricing/pricing.service.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/rules-proxy/rules.controller.ts
+++ b/blp/apps/core-api/src/rules-proxy/rules.controller.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/rules-proxy/rules.module.ts
+++ b/blp/apps/core-api/src/rules-proxy/rules.module.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/temporal/temporal.module.ts
+++ b/blp/apps/core-api/src/temporal/temporal.module.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/temporal/workflows.client.ts
+++ b/blp/apps/core-api/src/temporal/workflows.client.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/tenancy/tenancy.module.ts
+++ b/blp/apps/core-api/src/tenancy/tenancy.module.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/src/tenancy/tenant.interceptor.ts
+++ b/blp/apps/core-api/src/tenancy/tenant.interceptor.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/core-api/test/placeholder.spec.ts
+++ b/blp/apps/core-api/test/placeholder.spec.ts
@@ -1,0 +1,1 @@
+// Placeholder test suite for core API.

--- a/blp/apps/policy-bundle/build_bundle.py
+++ b/blp/apps/policy-bundle/build_bundle.py
@@ -1,0 +1,4 @@
+"""Placeholder script for building the OPA bundle."""
+
+if __name__ == "__main__":
+    print("Build bundle placeholder")

--- a/blp/apps/policy-bundle/src/policy.rego
+++ b/blp/apps/policy-bundle/src/policy.rego
@@ -1,0 +1,3 @@
+package blp.policy
+
+# Placeholder policy module.

--- a/blp/apps/policy-bundle/src/tests/policy_test.rego
+++ b/blp/apps/policy-bundle/src/tests/policy_test.rego
@@ -1,0 +1,3 @@
+package blp.policy
+
+# Placeholder tests.

--- a/blp/apps/rules-engine/app/api/routes_eval.py
+++ b/blp/apps/rules-engine/app/api/routes_eval.py
@@ -1,0 +1,1 @@
+# Placeholder for ${f}.

--- a/blp/apps/rules-engine/app/api/routes_rules.py
+++ b/blp/apps/rules-engine/app/api/routes_rules.py
@@ -1,0 +1,1 @@
+# Placeholder for ${f}.

--- a/blp/apps/rules-engine/app/core/config.py
+++ b/blp/apps/rules-engine/app/core/config.py
@@ -1,0 +1,1 @@
+# Placeholder for ${f}.

--- a/blp/apps/rules-engine/app/core/logging.py
+++ b/blp/apps/rules-engine/app/core/logging.py
@@ -1,0 +1,1 @@
+# Placeholder for ${f}.

--- a/blp/apps/rules-engine/app/dsl/operators.py
+++ b/blp/apps/rules-engine/app/dsl/operators.py
@@ -1,0 +1,1 @@
+# Placeholder for ${f}.

--- a/blp/apps/rules-engine/app/dsl/validator.py
+++ b/blp/apps/rules-engine/app/dsl/validator.py
@@ -1,0 +1,1 @@
+# Placeholder for ${f}.

--- a/blp/apps/rules-engine/app/main.py
+++ b/blp/apps/rules-engine/app/main.py
@@ -1,0 +1,1 @@
+# Placeholder for ${f}.

--- a/blp/apps/rules-engine/app/models/schemas.py
+++ b/blp/apps/rules-engine/app/models/schemas.py
@@ -1,0 +1,1 @@
+# Placeholder for ${f}.

--- a/blp/apps/rules-engine/app/services/catalog.py
+++ b/blp/apps/rules-engine/app/services/catalog.py
@@ -1,0 +1,1 @@
+# Placeholder for ${f}.

--- a/blp/apps/rules-engine/app/services/evaluator.py
+++ b/blp/apps/rules-engine/app/services/evaluator.py
@@ -1,0 +1,1 @@
+# Placeholder for ${f}.

--- a/blp/apps/rules-engine/app/services/regression.py
+++ b/blp/apps/rules-engine/app/services/regression.py
@@ -1,0 +1,1 @@
+# Placeholder for ${f}.

--- a/blp/apps/rules-engine/tests/test_eval_regression.py
+++ b/blp/apps/rules-engine/tests/test_eval_regression.py
@@ -1,0 +1,1 @@
+# Placeholder tests for ${f}.

--- a/blp/apps/rules-engine/tests/test_rules_dsl.py
+++ b/blp/apps/rules-engine/tests/test_rules_dsl.py
@@ -1,0 +1,1 @@
+# Placeholder tests for ${f}.

--- a/blp/apps/web-app-react/README.md
+++ b/blp/apps/web-app-react/README.md
@@ -1,0 +1,3 @@
+# Web App (React)
+
+Frontend scaffold placeholder.

--- a/blp/apps/worker/src/activities.ts
+++ b/blp/apps/worker/src/activities.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/worker/src/index.ts
+++ b/blp/apps/worker/src/index.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/apps/worker/src/workflows.ts
+++ b/blp/apps/worker/src/workflows.ts
@@ -1,0 +1,1 @@
+// Placeholder for ${f}.

--- a/blp/db/migrations/0001_init_tenancy.sql
+++ b/blp/db/migrations/0001_init_tenancy.sql
@@ -1,0 +1,1 @@
+-- Placeholder migration script for $f.

--- a/blp/db/migrations/0002_domain_core.sql
+++ b/blp/db/migrations/0002_domain_core.sql
@@ -1,0 +1,1 @@
+-- Placeholder migration script for $f.

--- a/blp/db/migrations/0003_rules_catalog.sql
+++ b/blp/db/migrations/0003_rules_catalog.sql
@@ -1,0 +1,1 @@
+-- Placeholder migration script for $f.

--- a/blp/db/migrations/0004_audit_and_retention.sql
+++ b/blp/db/migrations/0004_audit_and_retention.sql
@@ -1,0 +1,1 @@
+-- Placeholder migration script for $f.

--- a/blp/db/prisma/schema.prisma
+++ b/blp/db/prisma/schema.prisma
@@ -1,0 +1,1 @@
+// Placeholder Prisma schema mapping to PostgreSQL tables.

--- a/blp/db/seed/seed_reference_data.sql
+++ b/blp/db/seed/seed_reference_data.sql
@@ -1,0 +1,1 @@
+-- Placeholder seed data for retention policies, holidays, and reference categories.

--- a/blp/docs/ADRs/0001-architecture.md
+++ b/blp/docs/ADRs/0001-architecture.md
@@ -1,0 +1,6 @@
+# ADR 0001: High-Level Architecture
+
+- **Status**: Accepted
+- **Context**: Define the baseline architecture for the Broker-Lender Platform MVP.
+- **Decision**: Adopt a monorepo with a NestJS core API, FastAPI rules engine, Temporal workers, connector services, and PostgreSQL with RLS.
+- **Consequences**: Enables cohesive development across services with shared tooling while keeping service boundaries explicit.

--- a/blp/docs/APIs/core-api.yaml
+++ b/blp/docs/APIs/core-api.yaml
@@ -1,0 +1,5 @@
+openapi: 3.0.3
+info:
+  title: BLP Core API
+  version: 0.1.0
+paths: {}

--- a/blp/docs/APIs/rules-engine.yaml
+++ b/blp/docs/APIs/rules-engine.yaml
@@ -1,0 +1,5 @@
+openapi: 3.0.3
+info:
+  title: BLP Rules Engine
+  version: 0.1.0
+paths: {}

--- a/blp/docs/PRD.md
+++ b/blp/docs/PRD.md
@@ -1,0 +1,3 @@
+# Product Requirements Document
+
+This document will outline the high-level requirements for the Broker-Lender Platform MVP, covering multi-tenant theming, loan orchestration, rules management, and integrations.

--- a/blp/docs/Policies/policy-bundle.rego
+++ b/blp/docs/Policies/policy-bundle.rego
@@ -1,0 +1,3 @@
+package blp.policy
+
+# Placeholder for aggregated policy bundle.

--- a/blp/docs/Runbooks/DR.md
+++ b/blp/docs/Runbooks/DR.md
@@ -1,0 +1,3 @@
+# Disaster Recovery Runbook
+
+Placeholder for DR procedures covering database restoration, Temporal workflow replay, and connector failover.

--- a/blp/docs/Security/ThreatModel.md
+++ b/blp/docs/Security/ThreatModel.md
@@ -1,0 +1,3 @@
+# Threat Model
+
+This document will capture assets, actors, trust boundaries, and mitigations for the Broker-Lender Platform MVP.

--- a/blp/infra/docker-compose.dev.yml
+++ b/blp/infra/docker-compose.dev.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+
+services:
+  placeholder:
+    image: alpine:3
+    command: ["sleep", "infinity"]

--- a/blp/infra/helm/README.md
+++ b/blp/infra/helm/README.md
@@ -1,0 +1,3 @@
+# Helm Charts
+
+Placeholder for Kubernetes deployment manifests.

--- a/blp/package.json
+++ b/blp/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "blp",
+  "private": true,
+  "packageManager": "pnpm@9",
+  "workspaces": ["apps/*", "libs/*"],
+  "scripts": {
+    "build": "pnpm -r build",
+    "lint": "pnpm -r lint",
+    "test": "pnpm -r test",
+    "dev": "docker compose -f infra/docker-compose.dev.yml up --build"
+  }
+}

--- a/blp/pnpm-workspace.yaml
+++ b/blp/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "libs/*"


### PR DESCRIPTION
## Summary
- add initial Broker-Lender Platform monorepo directories and placeholder files
- scaffold docs, database migrations, service stubs, connectors, and infra placeholders
- configure pnpm workspace, git metadata, and CI workflow placeholders

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8147eb02483328a6f0306012c64ef