### PR TITLE
feat(db): add multi-tenant schema, seeds, and RLS checks

### DIFF
--- a/blp/db/migrations/0001_init_tenancy.sql
+++ b/blp/db/migrations/0001_init_tenancy.sql
@@ -1,1 +1,156 @@
--- Placeholder migration script for $f.
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+CREATE EXTENSION IF NOT EXISTS "citext";
+
+CREATE SCHEMA IF NOT EXISTS app;
+
+CREATE OR REPLACE FUNCTION app.current_tenant_id()
+RETURNS uuid
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT NULLIF(current_setting('app.tenant_id', true), '')::uuid;
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_id()
+RETURNS uuid
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT NULLIF(current_setting('app.user_id', true), '')::uuid;
+$$;
+
+CREATE OR REPLACE FUNCTION app.apply_tenant_id()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  configured_tenant uuid;
+BEGIN
+  configured_tenant := app.current_tenant_id();
+
+  IF TG_OP = 'UPDATE' AND NEW.tenant_id <> OLD.tenant_id THEN
+    RAISE EXCEPTION 'tenant_id is immutable';
+  END IF;
+
+  IF configured_tenant IS NULL THEN
+    IF NEW.tenant_id IS NULL THEN
+      RAISE EXCEPTION 'app.tenant_id must be configured before writing tenant scoped data';
+    END IF;
+  ELSE
+    IF NEW.tenant_id IS NULL THEN
+      NEW.tenant_id := configured_tenant;
+    ELSIF NEW.tenant_id <> configured_tenant THEN
+      RAISE EXCEPTION 'tenant scope violation (expected % but received %)', configured_tenant, NEW.tenant_id;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION app.set_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TYPE tenant_role AS ENUM ('owner', 'admin', 'loan_officer', 'processor', 'viewer');
+
+CREATE TABLE public.tenants (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug citext NOT NULL UNIQUE,
+  display_name text NOT NULL,
+  timezone text NOT NULL DEFAULT 'UTC',
+  contact_email text,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE public.users (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  email citext NOT NULL UNIQUE,
+  full_name text NOT NULL,
+  locale text NOT NULL DEFAULT 'en-US',
+  avatar_url text,
+  is_active boolean NOT NULL DEFAULT true,
+  last_seen_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE public.tenant_users (
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  role tenant_role NOT NULL DEFAULT 'viewer',
+  invited_at timestamptz,
+  accepted_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tenant_id, user_id)
+);
+
+CREATE INDEX idx_tenant_users_user_id ON public.tenant_users(user_id);
+
+CREATE TRIGGER tenants_set_updated_at
+BEFORE UPDATE ON public.tenants
+FOR EACH ROW
+EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER users_set_updated_at
+BEFORE UPDATE ON public.users
+FOR EACH ROW
+EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER tenant_users_set_updated_at
+BEFORE UPDATE ON public.tenant_users
+FOR EACH ROW
+EXECUTE FUNCTION app.set_updated_at();
+
+ALTER TABLE public.tenants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.tenant_users ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation_select
+ON public.tenants
+FOR SELECT USING (id = app.current_tenant_id());
+
+CREATE POLICY tenant_isolation_write
+ON public.tenants
+FOR ALL USING (id = app.current_tenant_id())
+WITH CHECK (id = app.current_tenant_id());
+
+CREATE POLICY users_isolation
+ON public.users
+FOR ALL
+USING (
+  id = app.current_user_id()
+  OR EXISTS (
+    SELECT 1
+    FROM public.tenant_users tu
+    WHERE tu.user_id = public.users.id
+      AND tu.tenant_id = app.current_tenant_id()
+  )
+)
+WITH CHECK (
+  id = app.current_user_id()
+  OR EXISTS (
+    SELECT 1
+    FROM public.tenant_users tu
+    WHERE tu.user_id = public.users.id
+      AND tu.tenant_id = app.current_tenant_id()
+  )
+);
+
+CREATE POLICY tenant_users_isolation
+ON public.tenant_users
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+COMMIT;

--- a/blp/db/migrations/0002_domain_core.sql
+++ b/blp/db/migrations/0002_domain_core.sql
@@ -1,1 +1,215 @@
--- Placeholder migration script for $f.
+BEGIN;
+
+CREATE TYPE borrower_type AS ENUM ('individual', 'business');
+CREATE TYPE loan_status AS ENUM ('draft', 'submitted', 'in_review', 'approved', 'funded', 'closed', 'withdrawn', 'declined');
+CREATE TYPE document_status AS ENUM ('pending', 'requested', 'received', 'validated', 'waived');
+CREATE TYPE task_status AS ENUM ('open', 'in_progress', 'blocked', 'completed', 'cancelled');
+CREATE TYPE task_priority AS ENUM ('low', 'medium', 'high', 'urgent');
+
+CREATE TABLE public.borrowers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  type borrower_type NOT NULL DEFAULT 'individual',
+  legal_name text NOT NULL,
+  email text,
+  phone text,
+  tax_identifier text,
+  date_of_birth date,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, id)
+);
+
+CREATE TABLE public.loans (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  primary_borrower_id uuid NOT NULL REFERENCES public.borrowers(id),
+  loan_number text NOT NULL,
+  product_type text,
+  purpose text,
+  status loan_status NOT NULL DEFAULT 'draft',
+  requested_amount numeric(16,2) NOT NULL DEFAULT 0,
+  currency_code char(3) NOT NULL DEFAULT 'USD',
+  interest_rate numeric(7,4),
+  submitted_at timestamptz,
+  decisioned_at timestamptz,
+  funded_at timestamptz,
+  closed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, loan_number),
+  UNIQUE (tenant_id, id)
+);
+
+ALTER TABLE public.loans
+  ADD CONSTRAINT loans_primary_borrower_fkey
+  FOREIGN KEY (primary_borrower_id)
+  REFERENCES public.borrowers(id)
+  ON DELETE RESTRICT;
+
+CREATE TABLE public.loan_borrowers (
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  loan_id uuid NOT NULL,
+  borrower_id uuid NOT NULL,
+  is_primary boolean NOT NULL DEFAULT false,
+  ownership_percent numeric(5,2),
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (loan_id, borrower_id),
+  CONSTRAINT loan_borrowers_tenant_fk FOREIGN KEY (tenant_id, loan_id)
+    REFERENCES public.loans(tenant_id, id) ON DELETE CASCADE,
+  CONSTRAINT loan_borrowers_borrower_fk FOREIGN KEY (tenant_id, borrower_id)
+    REFERENCES public.borrowers(tenant_id, id) ON DELETE CASCADE
+);
+
+CREATE TABLE public.document_categories (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  code text NOT NULL,
+  display_name text NOT NULL,
+  description text,
+  retention_category_code text,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, code)
+);
+
+CREATE TABLE public.loan_documents (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  loan_id uuid NOT NULL,
+  borrower_id uuid,
+  document_category_id uuid NOT NULL REFERENCES public.document_categories(id) ON DELETE RESTRICT,
+  file_name text NOT NULL,
+  storage_uri text NOT NULL,
+  file_size bigint,
+  checksum text,
+  status document_status NOT NULL DEFAULT 'pending',
+  uploaded_by_user_id uuid REFERENCES public.users(id),
+  uploaded_at timestamptz NOT NULL DEFAULT NOW(),
+  verified_at timestamptz,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, id),
+  CONSTRAINT loan_documents_tenant_fk FOREIGN KEY (tenant_id, loan_id)
+    REFERENCES public.loans(tenant_id, id) ON DELETE CASCADE,
+  CONSTRAINT loan_documents_borrower_fk FOREIGN KEY (tenant_id, borrower_id)
+    REFERENCES public.borrowers(tenant_id, id) ON DELETE SET NULL,
+  CONSTRAINT loan_documents_uploader_fk FOREIGN KEY (tenant_id, uploaded_by_user_id)
+    REFERENCES public.tenant_users(tenant_id, user_id) ON DELETE SET NULL
+);
+
+CREATE TABLE public.loan_tasks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  loan_id uuid NOT NULL,
+  title text NOT NULL,
+  description text,
+  status task_status NOT NULL DEFAULT 'open',
+  priority task_priority NOT NULL DEFAULT 'medium',
+  due_date date,
+  assigned_to_user_id uuid,
+  completed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, id),
+  CONSTRAINT loan_tasks_tenant_fk FOREIGN KEY (tenant_id, loan_id)
+    REFERENCES public.loans(tenant_id, id) ON DELETE CASCADE,
+  CONSTRAINT loan_tasks_assignee_fk FOREIGN KEY (tenant_id, assigned_to_user_id)
+    REFERENCES public.tenant_users(tenant_id, user_id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_loans_tenant_status ON public.loans(tenant_id, status);
+CREATE INDEX idx_loans_primary_borrower ON public.loans(primary_borrower_id);
+CREATE INDEX idx_loan_documents_loan_id ON public.loan_documents(loan_id);
+CREATE INDEX idx_loan_documents_status ON public.loan_documents(status);
+CREATE INDEX idx_loan_tasks_status ON public.loan_tasks(status);
+CREATE INDEX idx_loan_tasks_due_date ON public.loan_tasks(due_date);
+
+CREATE TRIGGER borrowers_set_updated_at
+BEFORE UPDATE ON public.borrowers
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER loans_set_updated_at
+BEFORE UPDATE ON public.loans
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER loan_borrowers_set_updated_at
+BEFORE UPDATE ON public.loan_borrowers
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER document_categories_set_updated_at
+BEFORE UPDATE ON public.document_categories
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER loan_documents_set_updated_at
+BEFORE UPDATE ON public.loan_documents
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER loan_tasks_set_updated_at
+BEFORE UPDATE ON public.loan_tasks
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER borrowers_set_tenant
+BEFORE INSERT OR UPDATE ON public.borrowers
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER loans_set_tenant
+BEFORE INSERT OR UPDATE ON public.loans
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER loan_borrowers_set_tenant
+BEFORE INSERT OR UPDATE ON public.loan_borrowers
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER document_categories_set_tenant
+BEFORE INSERT OR UPDATE ON public.document_categories
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER loan_documents_set_tenant
+BEFORE INSERT OR UPDATE ON public.loan_documents
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER loan_tasks_set_tenant
+BEFORE INSERT OR UPDATE ON public.loan_tasks
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+ALTER TABLE public.borrowers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.loans ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.loan_borrowers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.document_categories ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.loan_documents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.loan_tasks ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY borrowers_tenant_isolation
+ON public.borrowers
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY loans_tenant_isolation
+ON public.loans
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY loan_borrowers_tenant_isolation
+ON public.loan_borrowers
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY document_categories_tenant_isolation
+ON public.document_categories
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY loan_documents_tenant_isolation
+ON public.loan_documents
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY loan_tasks_tenant_isolation
+ON public.loan_tasks
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+COMMIT;

--- a/blp/db/migrations/0003_rules_catalog.sql
+++ b/blp/db/migrations/0003_rules_catalog.sql
@@ -1,1 +1,146 @@
--- Placeholder migration script for $f.
+BEGIN;
+
+CREATE TYPE rule_effect AS ENUM ('approve', 'manual_review', 'decline', 'notify');
+CREATE TYPE rule_severity AS ENUM ('info', 'warning', 'critical');
+
+CREATE TABLE public.rule_categories (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  code text NOT NULL,
+  display_name text NOT NULL,
+  description text,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, code),
+  UNIQUE (tenant_id, id)
+);
+
+CREATE TABLE public.rule_sets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  category_id uuid REFERENCES public.rule_categories(id) ON DELETE SET NULL,
+  code text NOT NULL,
+  name text NOT NULL,
+  description text,
+  trigger_event text NOT NULL,
+  is_active boolean NOT NULL DEFAULT true,
+  version integer NOT NULL DEFAULT 1,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, code),
+  UNIQUE (tenant_id, id)
+);
+
+ALTER TABLE public.rule_sets
+  ADD CONSTRAINT rule_sets_category_tenant_fk
+  FOREIGN KEY (tenant_id, category_id)
+  REFERENCES public.rule_categories(tenant_id, id);
+
+CREATE TABLE public.rule_definitions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  rule_set_id uuid NOT NULL REFERENCES public.rule_sets(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  description text,
+  trigger_event text NOT NULL,
+  priority integer NOT NULL DEFAULT 0,
+  effect rule_effect NOT NULL,
+  severity rule_severity NOT NULL DEFAULT 'info',
+  condition jsonb NOT NULL,
+  action jsonb NOT NULL DEFAULT '{}'::jsonb,
+  active_from timestamptz,
+  active_to timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, rule_set_id, name),
+  UNIQUE (tenant_id, id)
+);
+
+ALTER TABLE public.rule_definitions
+  ADD CONSTRAINT rule_definitions_set_tenant_fk
+  FOREIGN KEY (tenant_id, rule_set_id)
+  REFERENCES public.rule_sets(tenant_id, id)
+  ON DELETE CASCADE;
+
+CREATE TABLE public.rule_parameters (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  rule_definition_id uuid NOT NULL REFERENCES public.rule_definitions(id) ON DELETE CASCADE,
+  key text NOT NULL,
+  label text,
+  value_type text NOT NULL CHECK (value_type IN ('string', 'number', 'boolean', 'date', 'enum')),
+  is_required boolean NOT NULL DEFAULT false,
+  default_value jsonb,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, rule_definition_id, key)
+);
+
+ALTER TABLE public.rule_parameters
+  ADD CONSTRAINT rule_parameters_definition_tenant_fk
+  FOREIGN KEY (tenant_id, rule_definition_id)
+  REFERENCES public.rule_definitions(tenant_id, id)
+  ON DELETE CASCADE;
+
+CREATE INDEX idx_rule_sets_event_active ON public.rule_sets(tenant_id, trigger_event, is_active);
+CREATE INDEX idx_rule_definitions_priority ON public.rule_definitions(rule_set_id, priority DESC);
+CREATE INDEX idx_rule_definitions_trigger_event ON public.rule_definitions(tenant_id, trigger_event);
+
+CREATE TRIGGER rule_categories_set_updated_at
+BEFORE UPDATE ON public.rule_categories
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER rule_sets_set_updated_at
+BEFORE UPDATE ON public.rule_sets
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER rule_definitions_set_updated_at
+BEFORE UPDATE ON public.rule_definitions
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER rule_parameters_set_updated_at
+BEFORE UPDATE ON public.rule_parameters
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER rule_categories_set_tenant
+BEFORE INSERT OR UPDATE ON public.rule_categories
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER rule_sets_set_tenant
+BEFORE INSERT OR UPDATE ON public.rule_sets
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER rule_definitions_set_tenant
+BEFORE INSERT OR UPDATE ON public.rule_definitions
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER rule_parameters_set_tenant
+BEFORE INSERT OR UPDATE ON public.rule_parameters
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+ALTER TABLE public.rule_categories ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rule_sets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rule_definitions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rule_parameters ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY rule_categories_tenant_isolation
+ON public.rule_categories
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY rule_sets_tenant_isolation
+ON public.rule_sets
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY rule_definitions_tenant_isolation
+ON public.rule_definitions
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY rule_parameters_tenant_isolation
+ON public.rule_parameters
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+COMMIT;

--- a/blp/db/migrations/0004_audit_and_retention.sql
+++ b/blp/db/migrations/0004_audit_and_retention.sql
@@ -1,1 +1,223 @@
--- Placeholder migration script for $f.
+BEGIN;
+
+CREATE TABLE public.retention_categories (
+  code text PRIMARY KEY,
+  display_name text NOT NULL,
+  description text,
+  default_retention_months integer,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE public.retention_policies (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  category_code text NOT NULL REFERENCES public.retention_categories(code) ON DELETE RESTRICT,
+  name text NOT NULL,
+  retention_months integer NOT NULL CHECK (retention_months >= 0),
+  review_interval_months integer CHECK (review_interval_months >= 0),
+  disposition text NOT NULL,
+  hold_until_event text,
+  is_default boolean NOT NULL DEFAULT false,
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, name),
+  UNIQUE (tenant_id, id)
+);
+
+CREATE TABLE public.retention_policy_assignments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  policy_id uuid NOT NULL REFERENCES public.retention_policies(id) ON DELETE CASCADE,
+  resource_type text NOT NULL,
+  resource_identifier text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, resource_type, resource_identifier)
+);
+
+ALTER TABLE public.retention_policy_assignments
+  ADD CONSTRAINT retention_policy_assignments_policy_fk
+  FOREIGN KEY (tenant_id, policy_id)
+  REFERENCES public.retention_policies(tenant_id, id)
+  ON DELETE CASCADE;
+
+CREATE TABLE public.data_retention_exemptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  resource_type text NOT NULL,
+  resource_identifier text NOT NULL,
+  policy_id uuid REFERENCES public.retention_policies(id) ON DELETE SET NULL,
+  reason text NOT NULL,
+  granted_by_user_id uuid,
+  expires_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, resource_type, resource_identifier)
+);
+
+ALTER TABLE public.data_retention_exemptions
+  ADD CONSTRAINT data_retention_exemptions_granter_fk
+  FOREIGN KEY (tenant_id, granted_by_user_id)
+  REFERENCES public.tenant_users(tenant_id, user_id)
+  ON DELETE SET NULL;
+
+ALTER TABLE public.data_retention_exemptions
+  ADD CONSTRAINT data_retention_exemptions_policy_fk
+  FOREIGN KEY (tenant_id, policy_id)
+  REFERENCES public.retention_policies(tenant_id, id)
+  ON DELETE SET NULL;
+
+CREATE TABLE public.holiday_calendars (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  timezone text NOT NULL,
+  is_default boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, name),
+  UNIQUE (tenant_id, id)
+);
+
+CREATE TABLE public.holidays (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  calendar_id uuid NOT NULL REFERENCES public.holiday_calendars(id) ON DELETE CASCADE,
+  holiday_date date NOT NULL,
+  label text NOT NULL,
+  is_recurring boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (calendar_id, holiday_date, label)
+);
+
+ALTER TABLE public.holidays
+  ADD CONSTRAINT holidays_calendar_tenant_fk
+  FOREIGN KEY (tenant_id, calendar_id)
+  REFERENCES public.holiday_calendars(tenant_id, id)
+  ON DELETE CASCADE;
+
+CREATE TABLE public.audit_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  actor_id uuid,
+  actor_type text NOT NULL DEFAULT 'user',
+  action text NOT NULL,
+  entity_type text NOT NULL,
+  entity_id uuid,
+  entity_external_id text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  request_id uuid,
+  occurred_at timestamptz NOT NULL DEFAULT NOW(),
+  created_at timestamptz NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE public.audit_events
+  ADD CONSTRAINT audit_events_actor_fk
+  FOREIGN KEY (tenant_id, actor_id)
+  REFERENCES public.tenant_users(tenant_id, user_id)
+  ON DELETE SET NULL;
+
+ALTER TABLE public.document_categories
+  ADD CONSTRAINT document_categories_retention_category_fk
+  FOREIGN KEY (retention_category_code)
+  REFERENCES public.retention_categories(code)
+  ON DELETE SET NULL;
+
+CREATE INDEX idx_retention_policies_category ON public.retention_policies(tenant_id, category_code);
+CREATE INDEX idx_retention_policy_assignments_policy ON public.retention_policy_assignments(policy_id);
+CREATE INDEX idx_data_retention_exemptions_resource ON public.data_retention_exemptions(tenant_id, resource_type, resource_identifier);
+CREATE INDEX idx_holiday_calendars_default ON public.holiday_calendars(tenant_id, is_default) WHERE is_default = true;
+CREATE INDEX idx_holidays_date ON public.holidays(tenant_id, holiday_date);
+CREATE INDEX idx_audit_events_entity ON public.audit_events(tenant_id, entity_type, entity_id);
+CREATE INDEX idx_audit_events_request ON public.audit_events(tenant_id, request_id);
+
+CREATE TRIGGER retention_categories_set_updated_at
+BEFORE UPDATE ON public.retention_categories
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER retention_policies_set_updated_at
+BEFORE UPDATE ON public.retention_policies
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER data_retention_exemptions_set_updated_at
+BEFORE UPDATE ON public.data_retention_exemptions
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER holiday_calendars_set_updated_at
+BEFORE UPDATE ON public.holiday_calendars
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER holidays_set_updated_at
+BEFORE UPDATE ON public.holidays
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER retention_policies_set_tenant
+BEFORE INSERT OR UPDATE ON public.retention_policies
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER retention_policy_assignments_set_tenant
+BEFORE INSERT OR UPDATE ON public.retention_policy_assignments
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER data_retention_exemptions_set_tenant
+BEFORE INSERT OR UPDATE ON public.data_retention_exemptions
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER holiday_calendars_set_tenant
+BEFORE INSERT OR UPDATE ON public.holiday_calendars
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER holidays_set_tenant
+BEFORE INSERT OR UPDATE ON public.holidays
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER audit_events_set_tenant
+BEFORE INSERT OR UPDATE ON public.audit_events
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+ALTER TABLE public.retention_categories ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.retention_policies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.retention_policy_assignments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.data_retention_exemptions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.holiday_calendars ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.holidays ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.audit_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY retention_categories_public_read
+ON public.retention_categories
+FOR ALL USING (true)
+WITH CHECK (false);
+
+CREATE POLICY retention_policies_tenant_isolation
+ON public.retention_policies
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY retention_policy_assignments_tenant_isolation
+ON public.retention_policy_assignments
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY data_retention_exemptions_tenant_isolation
+ON public.data_retention_exemptions
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY holiday_calendars_tenant_isolation
+ON public.holiday_calendars
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY holidays_tenant_isolation
+ON public.holidays
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY audit_events_tenant_isolation
+ON public.audit_events
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+COMMIT;

--- a/blp/db/prisma/migrations/20240709000000_init/migration.sql
+++ b/blp/db/prisma/migrations/20240709000000_init/migration.sql
@@ -1,0 +1,741 @@
+-- Prisma shadow migration aligning with raw SQL migrations
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+CREATE EXTENSION IF NOT EXISTS "citext";
+
+CREATE SCHEMA IF NOT EXISTS app;
+
+CREATE OR REPLACE FUNCTION app.current_tenant_id()
+RETURNS uuid
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT NULLIF(current_setting('app.tenant_id', true), '')::uuid;
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_id()
+RETURNS uuid
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT NULLIF(current_setting('app.user_id', true), '')::uuid;
+$$;
+
+CREATE OR REPLACE FUNCTION app.apply_tenant_id()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  configured_tenant uuid;
+BEGIN
+  configured_tenant := app.current_tenant_id();
+
+  IF TG_OP = 'UPDATE' AND NEW.tenant_id <> OLD.tenant_id THEN
+    RAISE EXCEPTION 'tenant_id is immutable';
+  END IF;
+
+  IF configured_tenant IS NULL THEN
+    IF NEW.tenant_id IS NULL THEN
+      RAISE EXCEPTION 'app.tenant_id must be configured before writing tenant scoped data';
+    END IF;
+  ELSE
+    IF NEW.tenant_id IS NULL THEN
+      NEW.tenant_id := configured_tenant;
+    ELSIF NEW.tenant_id <> configured_tenant THEN
+      RAISE EXCEPTION 'tenant scope violation (expected % but received %)', configured_tenant, NEW.tenant_id;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION app.set_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TYPE tenant_role AS ENUM ('owner', 'admin', 'loan_officer', 'processor', 'viewer');
+
+CREATE TABLE public.tenants (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug citext NOT NULL UNIQUE,
+  display_name text NOT NULL,
+  timezone text NOT NULL DEFAULT 'UTC',
+  contact_email text,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE public.users (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  email citext NOT NULL UNIQUE,
+  full_name text NOT NULL,
+  locale text NOT NULL DEFAULT 'en-US',
+  avatar_url text,
+  is_active boolean NOT NULL DEFAULT true,
+  last_seen_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE public.tenant_users (
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  role tenant_role NOT NULL DEFAULT 'viewer',
+  invited_at timestamptz,
+  accepted_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tenant_id, user_id)
+);
+
+CREATE INDEX idx_tenant_users_user_id ON public.tenant_users(user_id);
+
+CREATE TRIGGER tenants_set_updated_at
+BEFORE UPDATE ON public.tenants
+FOR EACH ROW
+EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER users_set_updated_at
+BEFORE UPDATE ON public.users
+FOR EACH ROW
+EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER tenant_users_set_updated_at
+BEFORE UPDATE ON public.tenant_users
+FOR EACH ROW
+EXECUTE FUNCTION app.set_updated_at();
+
+ALTER TABLE public.tenants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.tenant_users ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation_select
+ON public.tenants
+FOR SELECT USING (id = app.current_tenant_id());
+
+CREATE POLICY tenant_isolation_write
+ON public.tenants
+FOR ALL USING (id = app.current_tenant_id())
+WITH CHECK (id = app.current_tenant_id());
+
+CREATE POLICY users_isolation
+ON public.users
+FOR ALL
+USING (
+  id = app.current_user_id()
+  OR EXISTS (
+    SELECT 1
+    FROM public.tenant_users tu
+    WHERE tu.user_id = public.users.id
+      AND tu.tenant_id = app.current_tenant_id()
+  )
+)
+WITH CHECK (
+  id = app.current_user_id()
+  OR EXISTS (
+    SELECT 1
+    FROM public.tenant_users tu
+    WHERE tu.user_id = public.users.id
+      AND tu.tenant_id = app.current_tenant_id()
+  )
+);
+
+CREATE POLICY tenant_users_isolation
+ON public.tenant_users
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+COMMIT;
+BEGIN;
+
+CREATE TYPE borrower_type AS ENUM ('individual', 'business');
+CREATE TYPE loan_status AS ENUM ('draft', 'submitted', 'in_review', 'approved', 'funded', 'closed', 'withdrawn', 'declined');
+CREATE TYPE document_status AS ENUM ('pending', 'requested', 'received', 'validated', 'waived');
+CREATE TYPE task_status AS ENUM ('open', 'in_progress', 'blocked', 'completed', 'cancelled');
+CREATE TYPE task_priority AS ENUM ('low', 'medium', 'high', 'urgent');
+
+CREATE TABLE public.borrowers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  type borrower_type NOT NULL DEFAULT 'individual',
+  legal_name text NOT NULL,
+  email text,
+  phone text,
+  tax_identifier text,
+  date_of_birth date,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, id)
+);
+
+CREATE TABLE public.loans (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  primary_borrower_id uuid NOT NULL REFERENCES public.borrowers(id),
+  loan_number text NOT NULL,
+  product_type text,
+  purpose text,
+  status loan_status NOT NULL DEFAULT 'draft',
+  requested_amount numeric(16,2) NOT NULL DEFAULT 0,
+  currency_code char(3) NOT NULL DEFAULT 'USD',
+  interest_rate numeric(7,4),
+  submitted_at timestamptz,
+  decisioned_at timestamptz,
+  funded_at timestamptz,
+  closed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, loan_number),
+  UNIQUE (tenant_id, id)
+);
+
+ALTER TABLE public.loans
+  ADD CONSTRAINT loans_primary_borrower_fkey
+  FOREIGN KEY (primary_borrower_id)
+  REFERENCES public.borrowers(id)
+  ON DELETE RESTRICT;
+
+CREATE TABLE public.loan_borrowers (
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  loan_id uuid NOT NULL,
+  borrower_id uuid NOT NULL,
+  is_primary boolean NOT NULL DEFAULT false,
+  ownership_percent numeric(5,2),
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (loan_id, borrower_id),
+  CONSTRAINT loan_borrowers_tenant_fk FOREIGN KEY (tenant_id, loan_id)
+    REFERENCES public.loans(tenant_id, id) ON DELETE CASCADE,
+  CONSTRAINT loan_borrowers_borrower_fk FOREIGN KEY (tenant_id, borrower_id)
+    REFERENCES public.borrowers(tenant_id, id) ON DELETE CASCADE
+);
+
+CREATE TABLE public.document_categories (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  code text NOT NULL,
+  display_name text NOT NULL,
+  description text,
+  retention_category_code text,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, code)
+);
+
+CREATE TABLE public.loan_documents (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  loan_id uuid NOT NULL,
+  borrower_id uuid,
+  document_category_id uuid NOT NULL REFERENCES public.document_categories(id) ON DELETE RESTRICT,
+  file_name text NOT NULL,
+  storage_uri text NOT NULL,
+  file_size bigint,
+  checksum text,
+  status document_status NOT NULL DEFAULT 'pending',
+  uploaded_by_user_id uuid REFERENCES public.users(id),
+  uploaded_at timestamptz NOT NULL DEFAULT NOW(),
+  verified_at timestamptz,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, id),
+  CONSTRAINT loan_documents_tenant_fk FOREIGN KEY (tenant_id, loan_id)
+    REFERENCES public.loans(tenant_id, id) ON DELETE CASCADE,
+  CONSTRAINT loan_documents_borrower_fk FOREIGN KEY (tenant_id, borrower_id)
+    REFERENCES public.borrowers(tenant_id, id) ON DELETE SET NULL,
+  CONSTRAINT loan_documents_uploader_fk FOREIGN KEY (tenant_id, uploaded_by_user_id)
+    REFERENCES public.tenant_users(tenant_id, user_id) ON DELETE SET NULL
+);
+
+CREATE TABLE public.loan_tasks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  loan_id uuid NOT NULL,
+  title text NOT NULL,
+  description text,
+  status task_status NOT NULL DEFAULT 'open',
+  priority task_priority NOT NULL DEFAULT 'medium',
+  due_date date,
+  assigned_to_user_id uuid,
+  completed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, id),
+  CONSTRAINT loan_tasks_tenant_fk FOREIGN KEY (tenant_id, loan_id)
+    REFERENCES public.loans(tenant_id, id) ON DELETE CASCADE,
+  CONSTRAINT loan_tasks_assignee_fk FOREIGN KEY (tenant_id, assigned_to_user_id)
+    REFERENCES public.tenant_users(tenant_id, user_id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_loans_tenant_status ON public.loans(tenant_id, status);
+CREATE INDEX idx_loans_primary_borrower ON public.loans(primary_borrower_id);
+CREATE INDEX idx_loan_documents_loan_id ON public.loan_documents(loan_id);
+CREATE INDEX idx_loan_documents_status ON public.loan_documents(status);
+CREATE INDEX idx_loan_tasks_status ON public.loan_tasks(status);
+CREATE INDEX idx_loan_tasks_due_date ON public.loan_tasks(due_date);
+
+CREATE TRIGGER borrowers_set_updated_at
+BEFORE UPDATE ON public.borrowers
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER loans_set_updated_at
+BEFORE UPDATE ON public.loans
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER loan_borrowers_set_updated_at
+BEFORE UPDATE ON public.loan_borrowers
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER document_categories_set_updated_at
+BEFORE UPDATE ON public.document_categories
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER loan_documents_set_updated_at
+BEFORE UPDATE ON public.loan_documents
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER loan_tasks_set_updated_at
+BEFORE UPDATE ON public.loan_tasks
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER borrowers_set_tenant
+BEFORE INSERT OR UPDATE ON public.borrowers
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER loans_set_tenant
+BEFORE INSERT OR UPDATE ON public.loans
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER loan_borrowers_set_tenant
+BEFORE INSERT OR UPDATE ON public.loan_borrowers
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER document_categories_set_tenant
+BEFORE INSERT OR UPDATE ON public.document_categories
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER loan_documents_set_tenant
+BEFORE INSERT OR UPDATE ON public.loan_documents
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER loan_tasks_set_tenant
+BEFORE INSERT OR UPDATE ON public.loan_tasks
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+ALTER TABLE public.borrowers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.loans ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.loan_borrowers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.document_categories ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.loan_documents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.loan_tasks ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY borrowers_tenant_isolation
+ON public.borrowers
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY loans_tenant_isolation
+ON public.loans
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY loan_borrowers_tenant_isolation
+ON public.loan_borrowers
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY document_categories_tenant_isolation
+ON public.document_categories
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY loan_documents_tenant_isolation
+ON public.loan_documents
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY loan_tasks_tenant_isolation
+ON public.loan_tasks
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+COMMIT;
+BEGIN;
+
+CREATE TYPE rule_effect AS ENUM ('approve', 'manual_review', 'decline', 'notify');
+CREATE TYPE rule_severity AS ENUM ('info', 'warning', 'critical');
+
+CREATE TABLE public.rule_categories (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  code text NOT NULL,
+  display_name text NOT NULL,
+  description text,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, code),
+  UNIQUE (tenant_id, id)
+);
+
+CREATE TABLE public.rule_sets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  category_id uuid REFERENCES public.rule_categories(id) ON DELETE SET NULL,
+  code text NOT NULL,
+  name text NOT NULL,
+  description text,
+  trigger_event text NOT NULL,
+  is_active boolean NOT NULL DEFAULT true,
+  version integer NOT NULL DEFAULT 1,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, code),
+  UNIQUE (tenant_id, id)
+);
+
+ALTER TABLE public.rule_sets
+  ADD CONSTRAINT rule_sets_category_tenant_fk
+  FOREIGN KEY (tenant_id, category_id)
+  REFERENCES public.rule_categories(tenant_id, id);
+
+CREATE TABLE public.rule_definitions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  rule_set_id uuid NOT NULL REFERENCES public.rule_sets(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  description text,
+  trigger_event text NOT NULL,
+  priority integer NOT NULL DEFAULT 0,
+  effect rule_effect NOT NULL,
+  severity rule_severity NOT NULL DEFAULT 'info',
+  condition jsonb NOT NULL,
+  action jsonb NOT NULL DEFAULT '{}'::jsonb,
+  active_from timestamptz,
+  active_to timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, rule_set_id, name),
+  UNIQUE (tenant_id, id)
+);
+
+ALTER TABLE public.rule_definitions
+  ADD CONSTRAINT rule_definitions_set_tenant_fk
+  FOREIGN KEY (tenant_id, rule_set_id)
+  REFERENCES public.rule_sets(tenant_id, id)
+  ON DELETE CASCADE;
+
+CREATE TABLE public.rule_parameters (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  rule_definition_id uuid NOT NULL REFERENCES public.rule_definitions(id) ON DELETE CASCADE,
+  key text NOT NULL,
+  label text,
+  value_type text NOT NULL CHECK (value_type IN ('string', 'number', 'boolean', 'date', 'enum')),
+  is_required boolean NOT NULL DEFAULT false,
+  default_value jsonb,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, rule_definition_id, key)
+);
+
+ALTER TABLE public.rule_parameters
+  ADD CONSTRAINT rule_parameters_definition_tenant_fk
+  FOREIGN KEY (tenant_id, rule_definition_id)
+  REFERENCES public.rule_definitions(tenant_id, id)
+  ON DELETE CASCADE;
+
+CREATE INDEX idx_rule_sets_event_active ON public.rule_sets(tenant_id, trigger_event, is_active);
+CREATE INDEX idx_rule_definitions_priority ON public.rule_definitions(rule_set_id, priority DESC);
+CREATE INDEX idx_rule_definitions_trigger_event ON public.rule_definitions(tenant_id, trigger_event);
+
+CREATE TRIGGER rule_categories_set_updated_at
+BEFORE UPDATE ON public.rule_categories
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER rule_sets_set_updated_at
+BEFORE UPDATE ON public.rule_sets
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER rule_definitions_set_updated_at
+BEFORE UPDATE ON public.rule_definitions
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER rule_parameters_set_updated_at
+BEFORE UPDATE ON public.rule_parameters
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER rule_categories_set_tenant
+BEFORE INSERT OR UPDATE ON public.rule_categories
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER rule_sets_set_tenant
+BEFORE INSERT OR UPDATE ON public.rule_sets
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER rule_definitions_set_tenant
+BEFORE INSERT OR UPDATE ON public.rule_definitions
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER rule_parameters_set_tenant
+BEFORE INSERT OR UPDATE ON public.rule_parameters
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+ALTER TABLE public.rule_categories ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rule_sets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rule_definitions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rule_parameters ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY rule_categories_tenant_isolation
+ON public.rule_categories
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY rule_sets_tenant_isolation
+ON public.rule_sets
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY rule_definitions_tenant_isolation
+ON public.rule_definitions
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY rule_parameters_tenant_isolation
+ON public.rule_parameters
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+COMMIT;
+BEGIN;
+
+CREATE TABLE public.retention_categories (
+  code text PRIMARY KEY,
+  display_name text NOT NULL,
+  description text,
+  default_retention_months integer,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE public.retention_policies (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  category_code text NOT NULL REFERENCES public.retention_categories(code) ON DELETE RESTRICT,
+  name text NOT NULL,
+  retention_months integer NOT NULL CHECK (retention_months >= 0),
+  review_interval_months integer CHECK (review_interval_months >= 0),
+  disposition text NOT NULL,
+  hold_until_event text,
+  is_default boolean NOT NULL DEFAULT false,
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, name),
+  UNIQUE (tenant_id, id)
+);
+
+CREATE TABLE public.retention_policy_assignments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  policy_id uuid NOT NULL REFERENCES public.retention_policies(id) ON DELETE CASCADE,
+  resource_type text NOT NULL,
+  resource_identifier text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, resource_type, resource_identifier)
+);
+
+ALTER TABLE public.retention_policy_assignments
+  ADD CONSTRAINT retention_policy_assignments_policy_fk
+  FOREIGN KEY (tenant_id, policy_id)
+  REFERENCES public.retention_policies(tenant_id, id)
+  ON DELETE CASCADE;
+
+CREATE TABLE public.data_retention_exemptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  resource_type text NOT NULL,
+  resource_identifier text NOT NULL,
+  policy_id uuid REFERENCES public.retention_policies(id) ON DELETE SET NULL,
+  reason text NOT NULL,
+  granted_by_user_id uuid,
+  expires_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, resource_type, resource_identifier)
+);
+
+ALTER TABLE public.data_retention_exemptions
+  ADD CONSTRAINT data_retention_exemptions_granter_fk
+  FOREIGN KEY (tenant_id, granted_by_user_id)
+  REFERENCES public.tenant_users(tenant_id, user_id)
+  ON DELETE SET NULL;
+
+ALTER TABLE public.data_retention_exemptions
+  ADD CONSTRAINT data_retention_exemptions_policy_fk
+  FOREIGN KEY (tenant_id, policy_id)
+  REFERENCES public.retention_policies(tenant_id, id)
+  ON DELETE SET NULL;
+
+CREATE TABLE public.holiday_calendars (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  timezone text NOT NULL,
+  is_default boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, name),
+  UNIQUE (tenant_id, id)
+);
+
+CREATE TABLE public.holidays (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  calendar_id uuid NOT NULL REFERENCES public.holiday_calendars(id) ON DELETE CASCADE,
+  holiday_date date NOT NULL,
+  label text NOT NULL,
+  is_recurring boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  UNIQUE (calendar_id, holiday_date, label)
+);
+
+ALTER TABLE public.holidays
+  ADD CONSTRAINT holidays_calendar_tenant_fk
+  FOREIGN KEY (tenant_id, calendar_id)
+  REFERENCES public.holiday_calendars(tenant_id, id)
+  ON DELETE CASCADE;
+
+CREATE TABLE public.audit_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  actor_id uuid,
+  actor_type text NOT NULL DEFAULT 'user',
+  action text NOT NULL,
+  entity_type text NOT NULL,
+  entity_id uuid,
+  entity_external_id text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  request_id uuid,
+  occurred_at timestamptz NOT NULL DEFAULT NOW(),
+  created_at timestamptz NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE public.audit_events
+  ADD CONSTRAINT audit_events_actor_fk
+  FOREIGN KEY (tenant_id, actor_id)
+  REFERENCES public.tenant_users(tenant_id, user_id)
+  ON DELETE SET NULL;
+
+ALTER TABLE public.document_categories
+  ADD CONSTRAINT document_categories_retention_category_fk
+  FOREIGN KEY (retention_category_code)
+  REFERENCES public.retention_categories(code)
+  ON DELETE SET NULL;
+
+CREATE INDEX idx_retention_policies_category ON public.retention_policies(tenant_id, category_code);
+CREATE INDEX idx_retention_policy_assignments_policy ON public.retention_policy_assignments(policy_id);
+CREATE INDEX idx_data_retention_exemptions_resource ON public.data_retention_exemptions(tenant_id, resource_type, resource_identifier);
+CREATE INDEX idx_holiday_calendars_default ON public.holiday_calendars(tenant_id, is_default) WHERE is_default = true;
+CREATE INDEX idx_holidays_date ON public.holidays(tenant_id, holiday_date);
+CREATE INDEX idx_audit_events_entity ON public.audit_events(tenant_id, entity_type, entity_id);
+CREATE INDEX idx_audit_events_request ON public.audit_events(tenant_id, request_id);
+
+CREATE TRIGGER retention_categories_set_updated_at
+BEFORE UPDATE ON public.retention_categories
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER retention_policies_set_updated_at
+BEFORE UPDATE ON public.retention_policies
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER data_retention_exemptions_set_updated_at
+BEFORE UPDATE ON public.data_retention_exemptions
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER holiday_calendars_set_updated_at
+BEFORE UPDATE ON public.holiday_calendars
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER holidays_set_updated_at
+BEFORE UPDATE ON public.holidays
+FOR EACH ROW EXECUTE FUNCTION app.set_updated_at();
+
+CREATE TRIGGER retention_policies_set_tenant
+BEFORE INSERT OR UPDATE ON public.retention_policies
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER retention_policy_assignments_set_tenant
+BEFORE INSERT OR UPDATE ON public.retention_policy_assignments
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER data_retention_exemptions_set_tenant
+BEFORE INSERT OR UPDATE ON public.data_retention_exemptions
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER holiday_calendars_set_tenant
+BEFORE INSERT OR UPDATE ON public.holiday_calendars
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER holidays_set_tenant
+BEFORE INSERT OR UPDATE ON public.holidays
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+CREATE TRIGGER audit_events_set_tenant
+BEFORE INSERT OR UPDATE ON public.audit_events
+FOR EACH ROW EXECUTE FUNCTION app.apply_tenant_id();
+
+ALTER TABLE public.retention_categories ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.retention_policies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.retention_policy_assignments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.data_retention_exemptions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.holiday_calendars ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.holidays ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.audit_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY retention_categories_public_read
+ON public.retention_categories
+FOR ALL USING (true)
+WITH CHECK (false);
+
+CREATE POLICY retention_policies_tenant_isolation
+ON public.retention_policies
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY retention_policy_assignments_tenant_isolation
+ON public.retention_policy_assignments
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY data_retention_exemptions_tenant_isolation
+ON public.data_retention_exemptions
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY holiday_calendars_tenant_isolation
+ON public.holiday_calendars
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY holidays_tenant_isolation
+ON public.holidays
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+CREATE POLICY audit_events_tenant_isolation
+ON public.audit_events
+FOR ALL USING (tenant_id = app.current_tenant_id())
+WITH CHECK (tenant_id = app.current_tenant_id());
+
+COMMIT;

--- a/blp/db/prisma/schema.prisma
+++ b/blp/db/prisma/schema.prisma
@@ -1,1 +1,481 @@
-// Placeholder Prisma schema mapping to PostgreSQL tables.
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum TenantRole {
+  owner
+  admin
+  loan_officer
+  processor
+  viewer
+  @@map("tenant_role")
+}
+
+enum BorrowerType {
+  individual
+  business
+  @@map("borrower_type")
+}
+
+enum LoanStatus {
+  draft
+  submitted
+  in_review
+  approved
+  funded
+  closed
+  withdrawn
+  declined
+  @@map("loan_status")
+}
+
+enum DocumentStatus {
+  pending
+  requested
+  received
+  validated
+  waived
+  @@map("document_status")
+}
+
+enum TaskStatus {
+  open
+  in_progress
+  blocked
+  completed
+  cancelled
+  @@map("task_status")
+}
+
+enum TaskPriority {
+  low
+  medium
+  high
+  urgent
+  @@map("task_priority")
+}
+
+enum RuleEffect {
+  approve
+  manual_review
+  decline
+  notify
+  @@map("rule_effect")
+}
+
+enum RuleSeverity {
+  info
+  warning
+  critical
+  @@map("rule_severity")
+}
+
+model Tenant {
+  id          String         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  slug        String         @unique @db.Citext
+  displayName String         @map("display_name")
+  timezone    String
+  contactEmail String?       @map("contact_email")
+  isActive    Boolean        @default(true) @map("is_active")
+  createdAt   DateTime       @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  updatedAt   DateTime       @default(dbgenerated("now()")) @map("updated_at") @db.Timestamptz(6)
+  tenantUsers TenantUser[]
+  borrowers   Borrower[]
+  loans       Loan[]
+  documentCategories DocumentCategory[]
+  ruleCategories RuleCategory[]
+  ruleSets    RuleSet[]
+  retentionPolicies RetentionPolicy[]
+  retentionPolicyAssignments RetentionPolicyAssignment[]
+  dataRetentionExemptions DataRetentionExemption[]
+  holidayCalendars HolidayCalendar[]
+  holidays    Holiday[]
+  auditEvents AuditEvent[]
+  loanDocuments LoanDocument[]
+  loanTasks   LoanTask[]
+  loanParticipants LoanBorrower[]
+
+  @@map("tenants")
+}
+
+model User {
+  id         String       @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  email      String       @unique @db.Citext
+  fullName   String       @map("full_name")
+  locale     String
+  avatarUrl  String?      @map("avatar_url")
+  isActive   Boolean      @default(true) @map("is_active")
+  lastSeenAt DateTime?    @map("last_seen_at") @db.Timestamptz(6)
+  createdAt  DateTime     @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  updatedAt  DateTime     @default(dbgenerated("now()")) @map("updated_at") @db.Timestamptz(6)
+  memberships TenantUser[]
+  uploadedDocuments LoanDocument[]
+
+  @@map("users")
+}
+
+model TenantUser {
+  tenantId   String      @map("tenant_id") @db.Uuid
+  userId     String      @map("user_id") @db.Uuid
+  role       TenantRole  @default(viewer)
+  invitedAt  DateTime?   @map("invited_at") @db.Timestamptz(6)
+  acceptedAt DateTime?   @map("accepted_at") @db.Timestamptz(6)
+  createdAt  DateTime    @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  updatedAt  DateTime    @default(dbgenerated("now()")) @map("updated_at") @db.Timestamptz(6)
+  tenant     Tenant      @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  user       User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  assignedTasks LoanTask[]
+  uploadedDocuments LoanDocument[] @relation("DocumentUploader")
+  grantedExemptions DataRetentionExemption[]
+  auditEvents AuditEvent[]
+
+  @@id([tenantId, userId])
+  @@map("tenant_users")
+}
+
+model Borrower {
+  id             String         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId       String         @map("tenant_id") @db.Uuid
+  type           BorrowerType   @default(individual)
+  legalName      String         @map("legal_name")
+  email          String?
+  phone          String?
+  taxIdentifier  String?        @map("tax_identifier")
+  dateOfBirth    DateTime?      @map("date_of_birth") @db.Date
+  createdAt      DateTime       @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  updatedAt      DateTime       @default(dbgenerated("now()")) @map("updated_at") @db.Timestamptz(6)
+  tenant         Tenant         @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  primaryLoans   Loan[]         @relation("PrimaryBorrower")
+  loanParticipants LoanBorrower[] @relation("LoanParticipantBorrower")
+  documents      LoanDocument[]
+
+  @@unique([tenantId, id])
+  @@map("borrowers")
+}
+
+model Loan {
+  id                String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId          String        @map("tenant_id") @db.Uuid
+  primaryBorrowerId String        @map("primary_borrower_id") @db.Uuid
+  loanNumber        String        @map("loan_number")
+  productType       String?       @map("product_type")
+  purpose           String?
+  status            LoanStatus    @default(draft)
+  requestedAmount   Decimal       @map("requested_amount") @db.Numeric(16, 2)
+  currencyCode      String        @map("currency_code") @db.Char(3)
+  interestRate      Decimal?      @map("interest_rate") @db.Numeric(7, 4)
+  submittedAt       DateTime?     @map("submitted_at") @db.Timestamptz(6)
+  decisionedAt      DateTime?     @map("decisioned_at") @db.Timestamptz(6)
+  fundedAt          DateTime?     @map("funded_at") @db.Timestamptz(6)
+  closedAt          DateTime?     @map("closed_at") @db.Timestamptz(6)
+  createdAt         DateTime      @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  updatedAt         DateTime      @default(dbgenerated("now()")) @map("updated_at") @db.Timestamptz(6)
+  tenant            Tenant        @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  primaryBorrower   Borrower      @relation("PrimaryBorrower", fields: [primaryBorrowerId], references: [id])
+  participants      LoanBorrower[] @relation("LoanParticipantLoan")
+  documents         LoanDocument[]
+  tasks             LoanTask[]
+
+  @@unique([tenantId, loanNumber])
+  @@unique([tenantId, id])
+  @@index([tenantId, status], name: "idx_loans_tenant_status")
+  @@index([primaryBorrowerId], name: "idx_loans_primary_borrower")
+  @@map("loans")
+}
+
+model LoanBorrower {
+  tenantId      String    @map("tenant_id") @db.Uuid
+  loanId        String    @map("loan_id") @db.Uuid
+  borrowerId    String    @map("borrower_id") @db.Uuid
+  isPrimary     Boolean   @map("is_primary") @default(false)
+  ownershipPercent Decimal? @map("ownership_percent") @db.Numeric(5, 2)
+  createdAt     DateTime  @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  updatedAt     DateTime  @default(dbgenerated("now()")) @map("updated_at") @db.Timestamptz(6)
+  tenant        Tenant    @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  loan          Loan      @relation(name: "LoanParticipantLoan", fields: [tenantId, loanId], references: [tenantId, id], onDelete: Cascade)
+  borrower      Borrower  @relation(name: "LoanParticipantBorrower", fields: [tenantId, borrowerId], references: [tenantId, id], onDelete: Cascade)
+
+  @@id([loanId, borrowerId])
+  @@map("loan_borrowers")
+}
+
+model DocumentCategory {
+  id                    String           @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId              String           @map("tenant_id") @db.Uuid
+  code                  String
+  displayName           String           @map("display_name")
+  description           String?
+  retentionCategoryCode String?          @map("retention_category_code")
+  createdAt             DateTime         @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  updatedAt             DateTime         @default(dbgenerated("now()")) @map("updated_at") @db.Timestamptz(6)
+  tenant                Tenant           @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  retentionCategory     RetentionCategory? @relation(fields: [retentionCategoryCode], references: [code])
+  documents             LoanDocument[]
+
+  @@unique([tenantId, code])
+  @@map("document_categories")
+}
+
+model LoanDocument {
+  id                 String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId           String        @map("tenant_id") @db.Uuid
+  loanId             String        @map("loan_id") @db.Uuid
+  borrowerId         String?       @map("borrower_id") @db.Uuid
+  documentCategoryId String        @map("document_category_id") @db.Uuid
+  fileName           String        @map("file_name")
+  storageUri         String        @map("storage_uri")
+  fileSize           BigInt?       @map("file_size")
+  checksum           String?
+  status             DocumentStatus @default(pending)
+  uploadedByUserId   String?       @map("uploaded_by_user_id") @db.Uuid
+  uploadedAt         DateTime      @default(dbgenerated("now()")) @map("uploaded_at") @db.Timestamptz(6)
+  verifiedAt         DateTime?     @map("verified_at") @db.Timestamptz(6)
+  metadata           Json          @default(dbgenerated("'{}'::jsonb"))
+  createdAt          DateTime      @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  updatedAt          DateTime      @default(dbgenerated("now()")) @map("updated_at") @db.Timestamptz(6)
+  tenant             Tenant        @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  loan               Loan          @relation(fields: [tenantId, loanId], references: [tenantId, id], onDelete: Cascade)
+  borrower           Borrower?     @relation(fields: [tenantId, borrowerId], references: [tenantId, id])
+  category           DocumentCategory @relation(fields: [documentCategoryId], references: [id])
+  uploadedBy         TenantUser?   @relation("DocumentUploader", fields: [tenantId, uploadedByUserId], references: [tenantId, userId])
+
+  @@unique([tenantId, id])
+  @@index([loanId], name: "idx_loan_documents_loan_id")
+  @@index([status], name: "idx_loan_documents_status")
+  @@map("loan_documents")
+}
+
+model LoanTask {
+  id               String       @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId         String       @map("tenant_id") @db.Uuid
+  loanId           String       @map("loan_id") @db.Uuid
+  title            String
+  description      String?
+  status           TaskStatus   @default(open)
+  priority         TaskPriority @default(medium)
+  dueDate          DateTime?    @map("due_date") @db.Date
+  assignedToUserId String?      @map("assigned_to_user_id") @db.Uuid
+  completedAt      DateTime?    @map("completed_at") @db.Timestamptz(6)
+  createdAt        DateTime     @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  updatedAt        DateTime     @default(dbgenerated("now()")) @map("updated_at") @db.Timestamptz(6)
+  tenant           Tenant       @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  loan             Loan         @relation(fields: [tenantId, loanId], references: [tenantId, id], onDelete: Cascade)
+  assignedTo       TenantUser?  @relation(fields: [tenantId, assignedToUserId], references: [tenantId, userId])
+
+  @@unique([tenantId, id])
+  @@index([status], name: "idx_loan_tasks_status")
+  @@index([dueDate], name: "idx_loan_tasks_due_date")
+  @@map("loan_tasks")
+}
+
+model RuleCategory {
+  id          String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId    String        @map("tenant_id") @db.Uuid
+  code        String
+  displayName String        @map("display_name")
+  description String?
+  createdAt   DateTime      @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  updatedAt   DateTime      @default(dbgenerated("now()")) @map("updated_at") @db.Timestamptz(6)
+  tenant      Tenant        @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  ruleSets    RuleSet[]
+
+  @@unique([tenantId, code])
+  @@map("rule_categories")
+}
+
+model RuleSet {
+  id          String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId    String        @map("tenant_id") @db.Uuid
+  categoryId  String?       @map("category_id") @db.Uuid
+  code        String
+  name        String
+  description String?
+  triggerEvent String       @map("trigger_event")
+  isActive    Boolean       @default(true) @map("is_active")
+  version     Int           @default(1)
+  createdAt   DateTime      @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  updatedAt   DateTime      @default(dbgenerated("now()")) @map("updated_at") @db.Timestamptz(6)
+  tenant      Tenant        @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  category    RuleCategory? @relation(fields: [tenantId, categoryId], references: [tenantId, id])
+  rules       RuleDefinition[]
+
+  @@unique([tenantId, code])
+  @@unique([tenantId, id])
+  @@index([tenantId, triggerEvent, isActive], name: "idx_rule_sets_event_active")
+  @@map("rule_sets")
+}
+
+model RuleDefinition {
+  id             String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId       String        @map("tenant_id") @db.Uuid
+  ruleSetId      String        @map("rule_set_id") @db.Uuid
+  name           String
+  description    String?
+  triggerEvent   String        @map("trigger_event")
+  priority       Int           @default(0)
+  effect         RuleEffect
+  severity       RuleSeverity  @default(info)
+  condition      Json
+  action         Json          @default(dbgenerated("'{}'::jsonb"))
+  activeFrom     DateTime?     @map("active_from") @db.Timestamptz(6)
+  activeTo       DateTime?     @map("active_to") @db.Timestamptz(6)
+  createdAt      DateTime      @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  updatedAt      DateTime      @default(dbgenerated("now()")) @map("updated_at") @db.Timestamptz(6)
+  tenant         Tenant        @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  ruleSet        RuleSet       @relation(fields: [tenantId, ruleSetId], references: [tenantId, id], onDelete: Cascade)
+  parameters     RuleParameter[]
+
+  @@unique([tenantId, ruleSetId, name])
+  @@unique([tenantId, id])
+  @@index([ruleSetId, priority], name: "idx_rule_definitions_priority")
+  @@index([tenantId, triggerEvent], name: "idx_rule_definitions_trigger_event")
+  @@map("rule_definitions")
+}
+
+model RuleParameter {
+  id               String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId         String        @map("tenant_id") @db.Uuid
+  ruleDefinitionId String        @map("rule_definition_id") @db.Uuid
+  key              String
+  label            String?
+  valueType        String        @map("value_type")
+  isRequired       Boolean       @default(false) @map("is_required")
+  defaultValue     Json?
+  createdAt        DateTime      @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  updatedAt        DateTime      @default(dbgenerated("now()")) @map("updated_at") @db.Timestamptz(6)
+  tenant           Tenant        @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  rule             RuleDefinition @relation(fields: [tenantId, ruleDefinitionId], references: [tenantId, id], onDelete: Cascade)
+
+  @@unique([tenantId, ruleDefinitionId, key])
+  @@map("rule_parameters")
+}
+
+model RetentionCategory {
+  code        String        @id
+  displayName String        @map("display_name")
+  description String?
+  defaultRetentionMonths Int? @map("default_retention_months")
+  isActive    Boolean      @default(true) @map("is_active")
+  createdAt   DateTime     @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  updatedAt   DateTime     @default(dbgenerated("now()")) @map("updated_at") @db.Timestamptz(6)
+  documentCategories DocumentCategory[]
+  retentionPolicies RetentionPolicy[]
+
+  @@map("retention_categories")
+}
+
+model RetentionPolicy {
+  id                String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId          String        @map("tenant_id") @db.Uuid
+  categoryCode      String        @map("category_code")
+  name              String
+  retentionMonths   Int           @map("retention_months")
+  reviewIntervalMonths Int?       @map("review_interval_months")
+  disposition       String
+  holdUntilEvent    String?       @map("hold_until_event")
+  isDefault         Boolean       @default(false) @map("is_default")
+  notes             String?
+  createdAt         DateTime      @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  updatedAt         DateTime      @default(dbgenerated("now()")) @map("updated_at") @db.Timestamptz(6)
+  tenant            Tenant        @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  category          RetentionCategory @relation(fields: [categoryCode], references: [code])
+  assignments       RetentionPolicyAssignment[]
+  exemptions        DataRetentionExemption[]
+
+  @@unique([tenantId, name])
+  @@unique([tenantId, id])
+  @@index([tenantId, categoryCode], name: "idx_retention_policies_category")
+  @@map("retention_policies")
+}
+
+model RetentionPolicyAssignment {
+  id                 String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId           String        @map("tenant_id") @db.Uuid
+  policyId           String        @map("policy_id") @db.Uuid
+  resourceType       String        @map("resource_type")
+  resourceIdentifier String        @map("resource_identifier")
+  createdAt          DateTime      @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  tenant             Tenant        @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  policy             RetentionPolicy @relation(fields: [tenantId, policyId], references: [tenantId, id], onDelete: Cascade)
+
+  @@unique([tenantId, resourceType, resourceIdentifier])
+  @@map("retention_policy_assignments")
+}
+
+model DataRetentionExemption {
+  id                 String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId           String        @map("tenant_id") @db.Uuid
+  resourceType       String        @map("resource_type")
+  resourceIdentifier String        @map("resource_identifier")
+  policyId           String?       @map("policy_id") @db.Uuid
+  reason             String
+  grantedByUserId    String?       @map("granted_by_user_id") @db.Uuid
+  expiresAt          DateTime?     @map("expires_at") @db.Timestamptz(6)
+  createdAt          DateTime      @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  updatedAt          DateTime      @default(dbgenerated("now()")) @map("updated_at") @db.Timestamptz(6)
+  tenant             Tenant        @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  policy             RetentionPolicy? @relation(fields: [tenantId, policyId], references: [tenantId, id], onDelete: SetNull)
+  grantedBy          TenantUser?   @relation(fields: [tenantId, grantedByUserId], references: [tenantId, userId], onDelete: SetNull)
+
+  @@unique([tenantId, resourceType, resourceIdentifier])
+  @@map("data_retention_exemptions")
+}
+
+model HolidayCalendar {
+  id         String     @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId   String     @map("tenant_id") @db.Uuid
+  name       String
+  timezone   String
+  isDefault  Boolean    @default(false) @map("is_default")
+  createdAt  DateTime   @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  updatedAt  DateTime   @default(dbgenerated("now()")) @map("updated_at") @db.Timestamptz(6)
+  tenant     Tenant     @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  holidays   Holiday[]
+
+  @@unique([tenantId, name])
+  @@unique([tenantId, id])
+  @@index([tenantId, isDefault], name: "idx_holiday_calendars_default")
+  @@map("holiday_calendars")
+}
+
+model Holiday {
+  id          String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId    String    @map("tenant_id") @db.Uuid
+  calendarId  String    @map("calendar_id") @db.Uuid
+  holidayDate DateTime  @map("holiday_date") @db.Date
+  label       String
+  isRecurring Boolean   @default(false) @map("is_recurring")
+  createdAt   DateTime  @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  tenant      Tenant    @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  calendar    HolidayCalendar @relation(fields: [tenantId, calendarId], references: [tenantId, id], onDelete: Cascade)
+
+  @@unique([calendarId, holidayDate, label])
+  @@index([tenantId, holidayDate], name: "idx_holidays_date")
+  @@map("holidays")
+}
+
+model AuditEvent {
+  id               String     @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId         String     @map("tenant_id") @db.Uuid
+  actorId          String?    @map("actor_id") @db.Uuid
+  actorType        String     @map("actor_type")
+  action           String
+  entityType       String     @map("entity_type")
+  entityId         String?    @map("entity_id") @db.Uuid
+  entityExternalId String?    @map("entity_external_id")
+  metadata         Json       @default(dbgenerated("'{}'::jsonb"))
+  requestId        String?    @map("request_id") @db.Uuid
+  occurredAt       DateTime   @default(dbgenerated("now()")) @map("occurred_at") @db.Timestamptz(6)
+  createdAt        DateTime   @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
+  tenant           Tenant     @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  actor            TenantUser? @relation(fields: [tenantId, actorId], references: [tenantId, userId], onDelete: SetNull)
+
+  @@index([tenantId, entityType, entityId], name: "idx_audit_events_entity")
+  @@index([tenantId, requestId], name: "idx_audit_events_request")
+  @@map("audit_events")
+}

--- a/blp/db/seed/seed_reference_data.sql
+++ b/blp/db/seed/seed_reference_data.sql
@@ -1,1 +1,212 @@
--- Placeholder seed data for retention policies, holidays, and reference categories.
+BEGIN;
+
+-- Baseline retention categories shared across tenants
+INSERT INTO public.retention_categories (code, display_name, description, default_retention_months, is_active)
+VALUES
+  ('loan_application', 'Loan Applications', 'Completed loan application packages.', 84, true),
+  ('supporting_document', 'Supporting Documents', 'Documents supplied to support underwriting decisions.', 60, true),
+  ('compliance', 'Compliance Artifacts', 'Regulatory filings, disclosures, and compliance evidence.', 120, true),
+  ('communication', 'Borrower Communications', 'Borrower-facing messages and disclosures.', 24, true)
+ON CONFLICT (code) DO UPDATE
+SET display_name = EXCLUDED.display_name,
+    description = EXCLUDED.description,
+    default_retention_months = EXCLUDED.default_retention_months,
+    is_active = EXCLUDED.is_active,
+    updated_at = NOW();
+
+-- Tenant fixtures for local development
+INSERT INTO public.tenants (id, slug, display_name, timezone, contact_email)
+VALUES
+  ('11111111-1111-4111-8111-111111111111', 'acme', 'Acme Lending', 'America/New_York', 'ops@acme.test'),
+  ('22222222-2222-4222-8222-222222222222', 'summit', 'Summit Capital', 'America/Los_Angeles', 'support@summit.test')
+ON CONFLICT (id) DO UPDATE
+SET display_name = EXCLUDED.display_name,
+    timezone = EXCLUDED.timezone,
+    contact_email = EXCLUDED.contact_email,
+    updated_at = NOW();
+
+-- User fixtures
+SELECT set_config('app.user_id', 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', true);
+INSERT INTO public.users (id, email, full_name, locale)
+VALUES ('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'admin@acme.test', 'Ada Admin', 'en-US')
+ON CONFLICT (id) DO UPDATE
+SET email = EXCLUDED.email,
+    full_name = EXCLUDED.full_name,
+    locale = EXCLUDED.locale,
+    updated_at = NOW();
+
+SELECT set_config('app.user_id', 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', true);
+INSERT INTO public.users (id, email, full_name, locale)
+VALUES ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', 'officer@acme.test', 'Owen Officer', 'en-US')
+ON CONFLICT (id) DO UPDATE
+SET email = EXCLUDED.email,
+    full_name = EXCLUDED.full_name,
+    locale = EXCLUDED.locale,
+    updated_at = NOW();
+
+SELECT set_config('app.user_id', 'cccccccc-cccc-4ccc-8ccc-cccccccccccc', true);
+INSERT INTO public.users (id, email, full_name, locale)
+VALUES ('cccccccc-cccc-4ccc-8ccc-cccccccccccc', 'owner@summit.test', 'Sierra Owner', 'en-US')
+ON CONFLICT (id) DO UPDATE
+SET email = EXCLUDED.email,
+    full_name = EXCLUDED.full_name,
+    locale = EXCLUDED.locale,
+    updated_at = NOW();
+
+SELECT set_config('app.user_id', '', true);
+
+-- Tenant memberships
+SELECT set_config('app.tenant_id', '11111111-1111-4111-8111-111111111111', true);
+INSERT INTO public.tenant_users (tenant_id, user_id, role, invited_at, accepted_at)
+VALUES
+  ('11111111-1111-4111-8111-111111111111', 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'owner', NOW(), NOW()),
+  ('11111111-1111-4111-8111-111111111111', 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', 'loan_officer', NOW(), NOW())
+ON CONFLICT (tenant_id, user_id) DO UPDATE
+SET role = EXCLUDED.role,
+    accepted_at = COALESCE(EXCLUDED.accepted_at, public.tenant_users.accepted_at),
+    updated_at = NOW();
+
+SELECT set_config('app.tenant_id', '22222222-2222-4222-8222-222222222222', true);
+INSERT INTO public.tenant_users (tenant_id, user_id, role, invited_at, accepted_at)
+VALUES ('22222222-2222-4222-8222-222222222222', 'cccccccc-cccc-4ccc-8ccc-cccccccccccc', 'owner', NOW(), NOW())
+ON CONFLICT (tenant_id, user_id) DO UPDATE
+SET role = EXCLUDED.role,
+    accepted_at = COALESCE(EXCLUDED.accepted_at, public.tenant_users.accepted_at),
+    updated_at = NOW();
+
+-- Document categories per tenant
+SELECT set_config('app.tenant_id', '11111111-1111-4111-8111-111111111111', true);
+INSERT INTO public.document_categories (id, tenant_id, code, display_name, description, retention_category_code)
+VALUES
+  ('33333333-3333-4333-8333-333333333331', '11111111-1111-4111-8111-111111111111', 'income_verification', 'Income Verification', 'Income statements, W-2s, and related documentation.', 'supporting_document'),
+  ('33333333-3333-4333-8333-333333333332', '11111111-1111-4111-8111-111111111111', 'identity', 'Identity', 'Borrower identification and KYC documents.', 'compliance'),
+  ('33333333-3333-4333-8333-333333333333', '11111111-1111-4111-8111-111111111111', 'compliance_report', 'Compliance Report', 'Annual compliance and audit reports.', 'compliance')
+ON CONFLICT (id) DO UPDATE
+SET code = EXCLUDED.code,
+    display_name = EXCLUDED.display_name,
+    description = EXCLUDED.description,
+    retention_category_code = EXCLUDED.retention_category_code,
+    updated_at = NOW();
+
+SELECT set_config('app.tenant_id', '22222222-2222-4222-8222-222222222222', true);
+INSERT INTO public.document_categories (id, tenant_id, code, display_name, description, retention_category_code)
+VALUES
+  ('44444444-4444-4444-8444-444444444441', '22222222-2222-4222-8222-222222222222', 'income_verification', 'Income Verification', 'Documents supporting borrower income.', 'supporting_document'),
+  ('44444444-4444-4444-8444-444444444442', '22222222-2222-4222-8222-222222222222', 'collateral', 'Collateral', 'Appraisals and collateral documentation.', 'supporting_document'),
+  ('44444444-4444-4444-8444-444444444443', '22222222-2222-4222-8222-222222222222', 'compliance_report', 'Compliance Report', 'Compliance documents requiring extended retention.', 'compliance')
+ON CONFLICT (id) DO UPDATE
+SET code = EXCLUDED.code,
+    display_name = EXCLUDED.display_name,
+    description = EXCLUDED.description,
+    retention_category_code = EXCLUDED.retention_category_code,
+    updated_at = NOW();
+
+-- Retention policies and assignments
+SELECT set_config('app.tenant_id', '11111111-1111-4111-8111-111111111111', true);
+INSERT INTO public.retention_policies (id, tenant_id, category_code, name, retention_months, review_interval_months, disposition, hold_until_event, is_default, notes)
+VALUES
+  ('55555555-5555-4555-8555-555555555551', '11111111-1111-4111-8111-111111111111', 'supporting_document', 'Acme Supporting Docs', 72, 24, 'secure_destroy', NULL, true, 'Extended to meet investor guidelines.'),
+  ('55555555-5555-4555-8555-555555555552', '11111111-1111-4111-8111-111111111111', 'compliance', 'Acme Compliance Archive', 120, 36, 'archive', NULL, false, 'Long-term compliance retention policy.')
+ON CONFLICT (id) DO UPDATE
+SET category_code = EXCLUDED.category_code,
+    name = EXCLUDED.name,
+    retention_months = EXCLUDED.retention_months,
+    review_interval_months = EXCLUDED.review_interval_months,
+    disposition = EXCLUDED.disposition,
+    hold_until_event = EXCLUDED.hold_until_event,
+    is_default = EXCLUDED.is_default,
+    notes = EXCLUDED.notes,
+    updated_at = NOW();
+
+INSERT INTO public.retention_policy_assignments (id, tenant_id, policy_id, resource_type, resource_identifier)
+VALUES
+  ('99999999-9999-4999-8999-999999999991', '11111111-1111-4111-8111-111111111111', '55555555-5555-4555-8555-555555555551', 'document_category', '33333333-3333-4333-8333-333333333331'),
+  ('99999999-9999-4999-8999-999999999992', '11111111-1111-4111-8111-111111111111', '55555555-5555-4555-8555-555555555552', 'document_category', '33333333-3333-4333-8333-333333333333')
+ON CONFLICT (id) DO UPDATE
+SET policy_id = EXCLUDED.policy_id,
+    resource_type = EXCLUDED.resource_type,
+    resource_identifier = EXCLUDED.resource_identifier;
+
+SELECT set_config('app.tenant_id', '22222222-2222-4222-8222-222222222222', true);
+INSERT INTO public.retention_policies (id, tenant_id, category_code, name, retention_months, review_interval_months, disposition, hold_until_event, is_default, notes)
+VALUES
+  ('66666666-6666-4666-8666-666666666661', '22222222-2222-4222-8222-222222222222', 'supporting_document', 'Summit Supporting Docs', 60, 24, 'secure_destroy', NULL, true, 'Aligns with state lending regulations.'),
+  ('66666666-6666-4666-8666-666666666662', '22222222-2222-4222-8222-222222222222', 'communication', 'Summit Communications', 36, 12, 'archive', NULL, false, 'Retention policy for outbound communications.')
+ON CONFLICT (id) DO UPDATE
+SET category_code = EXCLUDED.category_code,
+    name = EXCLUDED.name,
+    retention_months = EXCLUDED.retention_months,
+    review_interval_months = EXCLUDED.review_interval_months,
+    disposition = EXCLUDED.disposition,
+    hold_until_event = EXCLUDED.hold_until_event,
+    is_default = EXCLUDED.is_default,
+    notes = EXCLUDED.notes,
+    updated_at = NOW();
+
+INSERT INTO public.retention_policy_assignments (id, tenant_id, policy_id, resource_type, resource_identifier)
+VALUES
+  ('aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeee1', '22222222-2222-4222-8222-222222222222', '66666666-6666-4666-8666-666666666661', 'document_category', '44444444-4444-4444-8444-444444444441'),
+  ('aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeee2', '22222222-2222-4222-8222-222222222222', '66666666-6666-4666-8666-666666666662', 'document_category', '44444444-4444-4444-8444-444444444443')
+ON CONFLICT (id) DO UPDATE
+SET policy_id = EXCLUDED.policy_id,
+    resource_type = EXCLUDED.resource_type,
+    resource_identifier = EXCLUDED.resource_identifier;
+
+-- Sample retention exemption
+SELECT set_config('app.tenant_id', '11111111-1111-4111-8111-111111111111', true);
+INSERT INTO public.data_retention_exemptions (id, tenant_id, resource_type, resource_identifier, policy_id, reason, granted_by_user_id, expires_at)
+VALUES
+  ('bbbbbbbb-cccc-4ddd-8eee-fffffffffff1', '11111111-1111-4111-8111-111111111111', 'loan_document', 'legacy-audit-2021', '55555555-5555-4555-8555-555555555552', 'Litigation hold for 2021 audit.', 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', NOW() + INTERVAL '18 months')
+ON CONFLICT (id) DO UPDATE
+SET policy_id = EXCLUDED.policy_id,
+    reason = EXCLUDED.reason,
+    granted_by_user_id = EXCLUDED.granted_by_user_id,
+    expires_at = EXCLUDED.expires_at,
+    updated_at = NOW();
+
+-- Holiday calendars and key observances
+SELECT set_config('app.tenant_id', '11111111-1111-4111-8111-111111111111', true);
+INSERT INTO public.holiday_calendars (id, tenant_id, name, timezone, is_default)
+VALUES ('77777777-7777-4777-8777-777777777771', '11111111-1111-4111-8111-111111111111', 'US Federal Holidays', 'America/New_York', true)
+ON CONFLICT (id) DO UPDATE
+SET name = EXCLUDED.name,
+    timezone = EXCLUDED.timezone,
+    is_default = EXCLUDED.is_default,
+    updated_at = NOW();
+
+INSERT INTO public.holidays (id, tenant_id, calendar_id, holiday_date, label, is_recurring)
+VALUES
+  ('77777777-7777-4777-8777-777777777772', '11111111-1111-4111-8111-111111111111', '77777777-7777-4777-8777-777777777771', DATE '2024-01-01', 'New Year''s Day', true),
+  ('77777777-7777-4777-8777-777777777773', '11111111-1111-4111-8111-111111111111', '77777777-7777-4777-8777-777777777771', DATE '2024-07-04', 'Independence Day', true),
+  ('77777777-7777-4777-8777-777777777774', '11111111-1111-4111-8111-111111111111', '77777777-7777-4777-8777-777777777771', DATE '2024-11-28', 'Thanksgiving Day', false),
+  ('77777777-7777-4777-8777-777777777775', '11111111-1111-4111-8111-111111111111', '77777777-7777-4777-8777-777777777771', DATE '2024-12-25', 'Christmas Day', true)
+ON CONFLICT (id) DO UPDATE
+SET holiday_date = EXCLUDED.holiday_date,
+    label = EXCLUDED.label,
+    is_recurring = EXCLUDED.is_recurring;
+
+SELECT set_config('app.tenant_id', '22222222-2222-4222-8222-222222222222', true);
+INSERT INTO public.holiday_calendars (id, tenant_id, name, timezone, is_default)
+VALUES ('88888888-8888-4888-8888-888888888881', '22222222-2222-4222-8222-222222222222', 'CA Operational Holidays', 'America/Los_Angeles', true)
+ON CONFLICT (id) DO UPDATE
+SET name = EXCLUDED.name,
+    timezone = EXCLUDED.timezone,
+    is_default = EXCLUDED.is_default,
+    updated_at = NOW();
+
+INSERT INTO public.holidays (id, tenant_id, calendar_id, holiday_date, label, is_recurring)
+VALUES
+  ('88888888-8888-4888-8888-888888888882', '22222222-2222-4222-8222-222222222222', '88888888-8888-4888-8888-888888888881', DATE '2024-02-19', 'Presidents'' Day', true),
+  ('88888888-8888-4888-8888-888888888883', '22222222-2222-4222-8222-222222222222', '88888888-8888-4888-8888-888888888881', DATE '2024-09-02', 'Labor Day', true),
+  ('88888888-8888-4888-8888-888888888884', '22222222-2222-4222-8222-222222222222', '88888888-8888-4888-8888-888888888881', DATE '2024-11-29', 'Day After Thanksgiving', false),
+  ('88888888-8888-4888-8888-888888888885', '22222222-2222-4222-8222-222222222222', '88888888-8888-4888-8888-888888888881', DATE '2024-12-25', 'Christmas Day', true)
+ON CONFLICT (id) DO UPDATE
+SET holiday_date = EXCLUDED.holiday_date,
+    label = EXCLUDED.label,
+    is_recurring = EXCLUDED.is_recurring;
+
+-- Reset tenant scope
+SELECT set_config('app.tenant_id', '', true);
+SELECT set_config('app.user_id', '', true);
+
+COMMIT;

--- a/blp/db/tests/rls_policies.sql
+++ b/blp/db/tests/rls_policies.sql
@@ -1,0 +1,165 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+DO $$
+DECLARE
+  tenant_a uuid := gen_random_uuid();
+  tenant_b uuid := gen_random_uuid();
+  user_a uuid := gen_random_uuid();
+  user_b uuid := gen_random_uuid();
+  borrower_a uuid := gen_random_uuid();
+  borrower_b uuid := gen_random_uuid();
+  loan_a uuid := gen_random_uuid();
+  loan_b uuid := gen_random_uuid();
+  category_a uuid := gen_random_uuid();
+  category_b uuid := gen_random_uuid();
+  doc_a uuid := gen_random_uuid();
+  doc_b uuid := gen_random_uuid();
+  task_a uuid := gen_random_uuid();
+  task_b uuid := gen_random_uuid();
+  rows_changed integer;
+BEGIN
+  -- Reset scoping configuration
+  PERFORM set_config('app.tenant_id', '', true);
+  PERFORM set_config('app.user_id', '', true);
+
+  -- Seed tenants
+  PERFORM set_config('app.tenant_id', tenant_a::text, true);
+  INSERT INTO public.tenants (id, slug, display_name, timezone)
+  VALUES (tenant_a, 'rls-a', 'RLS Tenant A', 'UTC')
+  ON CONFLICT DO NOTHING;
+
+  PERFORM set_config('app.tenant_id', tenant_b::text, true);
+  INSERT INTO public.tenants (id, slug, display_name, timezone)
+  VALUES (tenant_b, 'rls-b', 'RLS Tenant B', 'UTC')
+  ON CONFLICT DO NOTHING;
+
+  -- Seed users
+  PERFORM set_config('app.user_id', user_a::text, true);
+  INSERT INTO public.users (id, email, full_name)
+  VALUES (user_a, 'rls-a@example.test', 'Tenant A User')
+  ON CONFLICT DO NOTHING;
+
+  PERFORM set_config('app.user_id', user_b::text, true);
+  INSERT INTO public.users (id, email, full_name)
+  VALUES (user_b, 'rls-b@example.test', 'Tenant B User')
+  ON CONFLICT DO NOTHING;
+
+  -- Tenant memberships and categories
+  PERFORM set_config('app.user_id', '', true);
+
+  PERFORM set_config('app.tenant_id', tenant_a::text, true);
+  INSERT INTO public.tenant_users (tenant_id, user_id, role, invited_at, accepted_at)
+  VALUES (tenant_a, user_a, 'owner', NOW(), NOW())
+  ON CONFLICT DO NOTHING;
+
+  INSERT INTO public.document_categories (id, tenant_id, code, display_name)
+  VALUES (category_a, tenant_a, 'rls_income', 'RLS Income A')
+  ON CONFLICT DO NOTHING;
+
+  PERFORM set_config('app.tenant_id', tenant_b::text, true);
+  INSERT INTO public.tenant_users (tenant_id, user_id, role, invited_at, accepted_at)
+  VALUES (tenant_b, user_b, 'owner', NOW(), NOW())
+  ON CONFLICT DO NOTHING;
+
+  INSERT INTO public.document_categories (id, tenant_id, code, display_name)
+  VALUES (category_b, tenant_b, 'rls_income', 'RLS Income B')
+  ON CONFLICT DO NOTHING;
+
+  -- Create borrower, loan, document, and task per tenant
+  PERFORM set_config('app.user_id', user_a::text, true);
+  PERFORM set_config('app.tenant_id', tenant_a::text, true);
+  INSERT INTO public.borrowers (id, tenant_id, legal_name)
+  VALUES (borrower_a, tenant_a, 'Borrower A')
+  ON CONFLICT DO NOTHING;
+
+  INSERT INTO public.loans (id, tenant_id, primary_borrower_id, loan_number, status, requested_amount)
+  VALUES (loan_a, tenant_a, borrower_a, 'A-001', 'submitted', 100000)
+  ON CONFLICT DO NOTHING;
+
+  INSERT INTO public.loan_borrowers (tenant_id, loan_id, borrower_id, is_primary)
+  VALUES (tenant_a, loan_a, borrower_a, true)
+  ON CONFLICT DO NOTHING;
+
+  INSERT INTO public.loan_documents (id, tenant_id, loan_id, borrower_id, document_category_id, file_name, storage_uri, status, uploaded_by_user_id)
+  VALUES (doc_a, tenant_a, loan_a, borrower_a, category_a, 'income.pdf', 's3://a/income.pdf', 'received', user_a)
+  ON CONFLICT DO NOTHING;
+
+  INSERT INTO public.loan_tasks (id, tenant_id, loan_id, title, assigned_to_user_id)
+  VALUES (task_a, tenant_a, loan_a, 'Collect updated income docs', user_a)
+  ON CONFLICT DO NOTHING;
+
+  PERFORM set_config('app.user_id', user_b::text, true);
+  PERFORM set_config('app.tenant_id', tenant_b::text, true);
+  INSERT INTO public.borrowers (id, tenant_id, legal_name)
+  VALUES (borrower_b, tenant_b, 'Borrower B')
+  ON CONFLICT DO NOTHING;
+
+  INSERT INTO public.loans (id, tenant_id, primary_borrower_id, loan_number, status, requested_amount)
+  VALUES (loan_b, tenant_b, borrower_b, 'B-001', 'submitted', 150000)
+  ON CONFLICT DO NOTHING;
+
+  INSERT INTO public.loan_borrowers (tenant_id, loan_id, borrower_id, is_primary)
+  VALUES (tenant_b, loan_b, borrower_b, true)
+  ON CONFLICT DO NOTHING;
+
+  INSERT INTO public.loan_documents (id, tenant_id, loan_id, borrower_id, document_category_id, file_name, storage_uri, status, uploaded_by_user_id)
+  VALUES (doc_b, tenant_b, loan_b, borrower_b, category_b, 'income.pdf', 's3://b/income.pdf', 'received', user_b)
+  ON CONFLICT DO NOTHING;
+
+  INSERT INTO public.loan_tasks (id, tenant_id, loan_id, title, assigned_to_user_id)
+  VALUES (task_b, tenant_b, loan_b, 'Collect compliance certificate', user_b)
+  ON CONFLICT DO NOTHING;
+
+  -- Assertions: tenant A cannot see tenant B data
+  PERFORM set_config('app.user_id', user_a::text, true);
+  PERFORM set_config('app.tenant_id', tenant_a::text, true);
+
+  IF (SELECT COUNT(*) FROM public.loans WHERE id = loan_b) > 0 THEN
+    RAISE EXCEPTION 'Tenant A unexpectedly read tenant B loan';
+  END IF;
+
+  UPDATE public.loans SET purpose = 'illegal update' WHERE id = loan_b;
+  GET DIAGNOSTICS rows_changed = ROW_COUNT;
+  IF rows_changed > 0 THEN
+    RAISE EXCEPTION 'Tenant A updated tenant B loan through RLS';
+  END IF;
+
+  DELETE FROM public.loan_documents WHERE id = doc_b;
+  GET DIAGNOSTICS rows_changed = ROW_COUNT;
+  IF rows_changed > 0 THEN
+    RAISE EXCEPTION 'Tenant A deleted tenant B document through RLS';
+  END IF;
+
+  BEGIN
+    INSERT INTO public.loan_documents (id, tenant_id, loan_id, document_category_id, file_name, storage_uri)
+    VALUES (gen_random_uuid(), tenant_b, loan_b, category_b, 'bad.pdf', 's3://bad.pdf');
+    RAISE EXCEPTION 'Tenant scoping trigger failed to reject mismatched tenant insert';
+  EXCEPTION
+    WHEN others THEN
+      -- Expected: tenant mismatch should raise an error
+      NULL;
+  END;
+
+  -- Assertions: tenant B cannot see tenant A data
+  PERFORM set_config('app.user_id', user_b::text, true);
+  PERFORM set_config('app.tenant_id', tenant_b::text, true);
+
+  IF (SELECT COUNT(*) FROM public.borrowers WHERE id = borrower_a) > 0 THEN
+    RAISE EXCEPTION 'Tenant B unexpectedly read tenant A borrower';
+  END IF;
+
+  UPDATE public.loan_tasks SET status = 'completed' WHERE id = task_a;
+  GET DIAGNOSTICS rows_changed = ROW_COUNT;
+  IF rows_changed > 0 THEN
+    RAISE EXCEPTION 'Tenant B updated tenant A task through RLS';
+  END IF;
+
+  -- Clean up scope
+  PERFORM set_config('app.tenant_id', '', true);
+  PERFORM set_config('app.user_id', '', true);
+END;
+$$;
+
+ROLLBACK;

--- a/blp/db/tests/run_rls_checks.sh
+++ b/blp/db/tests/run_rls_checks.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL must be set to run RLS checks" >&2
+  exit 1
+fi
+
+psql "${DATABASE_URL}" -v ON_ERROR_STOP=1 -f "$(dirname "$0")/rls_policies.sql"

--- a/blp/package.json
+++ b/blp/package.json
@@ -7,6 +7,7 @@
     "build": "pnpm -r build",
     "lint": "pnpm -r lint",
     "test": "pnpm -r test",
+    "test:rls": "bash db/tests/run_rls_checks.sh",
     "dev": "docker compose -f infra/docker-compose.dev.yml up --build"
   }
 }


### PR DESCRIPTION
## Summary
- define PostgreSQL tenancy, loan, rules, and audit/retention tables with triggers, indexes, and RLS enforcement
- seed baseline tenants, retention policies, document categories, holidays, and fixtures for local development
- mirror the schema in Prisma, add an initial migration, and provide an automated RLS regression script exposed via `pnpm test:rls`

## Testing
- Not run (requires a PostgreSQL DATABASE_URL for execution)


------
https://chatgpt.com/codex/tasks/task_e_68d8166d5e248332a06fa2d389a8540b