### PR TITLE
Implement connectors services, policy bundle, worker, and dev stack

### DIFF
--- a/blp/README.md
+++ b/blp/README.md
@@ -3,3 +3,26 @@
 This repository contains the initial scaffolding for the Broker-Lender Platform (BLP) MVP. It provides structured directories, configuration stubs, and placeholder documentation for the database, backend services, rules engine, policy bundles, connectors, and workflow workers.
 
 The generated structure follows the architecture described in the specification, enabling further implementation of PostgreSQL with Row-Level Security, NestJS-based APIs, FastAPI rules engine, Auth0/OPA authorization, connector services, and Temporal workflows.
+
+## Local development
+
+1. Build the OPA policy bundle so the `opa` container can mount the compiled artifact:
+   ```bash
+   cd apps/policy-bundle
+   python build_bundle.py --version dev --signing-key local
+   ```
+2. Start the local stack:
+   ```bash
+   cd ../..
+   docker compose -f infra/docker-compose.dev.yml up --build
+   ```
+3. Once the containers are healthy, the following endpoints are available:
+   - Postgres: `localhost:5432`
+   - Redis: `localhost:6379`
+   - Temporal: `localhost:7233` with UI on `http://localhost:8080`
+   - OPA API: `http://localhost:8181`
+   - MinIO console: `http://localhost:9001`
+   - Connectors: `http://localhost:3001-3004`
+   - Worker service: background worker connected to Temporal
+
+Stop the stack with `docker compose -f infra/docker-compose.dev.yml down`.

--- a/blp/apps/connectors/aus-gateway/package.json
+++ b/blp/apps/connectors/aus-gateway/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "aus-gateway",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "ts-node src/server.ts",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "helmet": "^7.0.0"
+  },
+  "devDependencies": {
+    "@pact-foundation/pact": "^12.0.0",
+    "@types/express": "^4.17.17",
+    "supertest": "^6.3.3",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.3.0",
+    "vitest": "^1.4.0"
+  }
+}

--- a/blp/apps/connectors/aus-gateway/src/mappers.ts
+++ b/blp/apps/connectors/aus-gateway/src/mappers.ts
@@ -1,1 +1,44 @@
-// Placeholder for ${f}.
+export interface AUSSubmissionRequest {
+  loanId: string;
+  dti: number;
+  ltv: number;
+  creditScore: number;
+}
+
+export interface AUSAdapterPayload {
+  caseNumber: string;
+  debtToIncome: number;
+  loanToValue: number;
+  fico: number;
+}
+
+export interface AUSDecision {
+  loanId: string;
+  result: 'APPROVED' | 'REFER' | 'MANUAL';
+  reasons: string[];
+}
+
+export interface AUSAdapterResponse {
+  decisionCode: 'APPROVED' | 'REFER' | 'MANUAL';
+  reasons: string[];
+}
+
+export function mapToAdapterPayload(request: AUSSubmissionRequest): AUSAdapterPayload {
+  return {
+    caseNumber: request.loanId,
+    debtToIncome: request.dti,
+    loanToValue: request.ltv,
+    fico: request.creditScore,
+  };
+}
+
+export function mapFromAdapterResponse(
+  request: AUSSubmissionRequest,
+  response: AUSAdapterResponse,
+): AUSDecision {
+  return {
+    loanId: request.loanId,
+    result: response.decisionCode,
+    reasons: response.reasons,
+  };
+}

--- a/blp/apps/connectors/aus-gateway/src/server.ts
+++ b/blp/apps/connectors/aus-gateway/src/server.ts
@@ -1,1 +1,35 @@
-// Placeholder for ${f}.
+import express from 'express';
+import helmet from 'helmet';
+import { AUSGatewayService } from './service';
+import { AUSSubmissionRequest } from './mappers';
+
+export function createServer(service = new AUSGatewayService()) {
+  const app = express();
+  app.use(helmet());
+  app.use(express.json());
+
+  app.post('/api/v1/aus/submit', async (req, res) => {
+    try {
+      const request = req.body as AUSSubmissionRequest;
+      const decision = await service.submitCase(request);
+      res.json(decision);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      res.status(400).json({ error: message });
+    }
+  });
+
+  app.get('/health', (_req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  return app;
+}
+
+if (require.main === module) {
+  const port = process.env.PORT ? Number(process.env.PORT) : 3003;
+  createServer().listen(port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`AUS gateway listening on ${port}`);
+  });
+}

--- a/blp/apps/connectors/aus-gateway/src/service.ts
+++ b/blp/apps/connectors/aus-gateway/src/service.ts
@@ -1,1 +1,45 @@
-// Placeholder for ${f}.
+import {
+  AUSAdapterPayload,
+  AUSAdapterResponse,
+  AUSDecision,
+  AUSSubmissionRequest,
+  mapFromAdapterResponse,
+  mapToAdapterPayload,
+} from './mappers';
+
+export interface AUSAdapter {
+  submit(payload: AUSAdapterPayload): Promise<AUSAdapterResponse>;
+}
+
+class MockAUSAdapter implements AUSAdapter {
+  async submit(payload: AUSAdapterPayload): Promise<AUSAdapterResponse> {
+    if (payload.fico < 620) {
+      return {
+        decisionCode: 'MANUAL',
+        reasons: ['Credit score below automated threshold'],
+      };
+    }
+
+    if (payload.debtToIncome > 0.5 || payload.loanToValue > 0.9) {
+      return {
+        decisionCode: 'REFER',
+        reasons: ['High DTI or LTV'],
+      };
+    }
+
+    return {
+      decisionCode: 'APPROVED',
+      reasons: [],
+    };
+  }
+}
+
+export class AUSGatewayService {
+  constructor(private readonly adapter: AUSAdapter = new MockAUSAdapter()) {}
+
+  async submitCase(request: AUSSubmissionRequest): Promise<AUSDecision> {
+    const payload = mapToAdapterPayload(request);
+    const response = await this.adapter.submit(payload);
+    return mapFromAdapterResponse(request, response);
+  }
+}

--- a/blp/apps/connectors/aus-gateway/test/contract.pact.ts
+++ b/blp/apps/connectors/aus-gateway/test/contract.pact.ts
@@ -1,0 +1,55 @@
+import path from 'node:path';
+import { Matchers, Pact } from '@pact-foundation/pact';
+import request from 'supertest';
+import { createServer } from '../src/server';
+
+const provider = new Pact({
+  consumer: 'CoreAPI',
+  provider: 'AUSGateway',
+  dir: path.resolve(__dirname, '../../pacts'),
+  spec: 3,
+});
+
+describe('AUS Gateway Pact', () => {
+  beforeAll(() => provider.setup());
+  afterAll(() => provider.finalize());
+  afterEach(() => provider.verify());
+
+  it('returns an automated decision', async () => {
+    await provider.addInteraction({
+      state: 'loan submission exists',
+      uponReceiving: 'an AUS submission',
+      withRequest: {
+        method: 'POST',
+        path: '/api/v1/aus/submit',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: {
+          loanId: 'loan-1',
+          dti: 0.35,
+          ltv: 0.8,
+          creditScore: 720,
+        },
+      },
+      willRespondWith: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+        },
+        body: {
+          loanId: 'loan-1',
+          result: Matchers.like('APPROVED'),
+          reasons: Matchers.eachLike('Automated approval', { min: 0 }),
+        },
+      },
+    });
+
+    const res = await request(createServer())
+      .post('/api/v1/aus/submit')
+      .send({ loanId: 'loan-1', dti: 0.35, ltv: 0.8, creditScore: 720 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.loanId).toBe('loan-1');
+  });
+});

--- a/blp/apps/connectors/aus-gateway/tsconfig.json
+++ b/blp/apps/connectors/aus-gateway/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "target": "ES2020",
+    "moduleResolution": "Node",
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["dist"]
+}

--- a/blp/apps/connectors/credit/package.json
+++ b/blp/apps/connectors/credit/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "credit",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "ts-node src/server.ts",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "helmet": "^7.0.0"
+  },
+  "devDependencies": {
+    "@pact-foundation/pact": "^12.0.0",
+    "@types/express": "^4.17.17",
+    "supertest": "^6.3.3",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.3.0",
+    "vitest": "^1.4.0"
+  }
+}

--- a/blp/apps/connectors/credit/src/mappers.ts
+++ b/blp/apps/connectors/credit/src/mappers.ts
@@ -1,1 +1,49 @@
-// Placeholder for ${f}.
+export interface CreditReportRequest {
+  borrowerId: string;
+  ssn: string;
+  includeScore?: boolean;
+}
+
+export interface CreditAdapterPayload {
+  subjectReference: string;
+  social: string;
+  includeScore: boolean;
+}
+
+export interface CreditReport {
+  borrowerId: string;
+  tradelines: Array<{
+    creditor: string;
+    balance: number;
+    status: 'OPEN' | 'CLOSED';
+  }>;
+  score?: number;
+}
+
+export interface CreditAdapterResponse {
+  tradelines: Array<{
+    creditor: string;
+    balance: number;
+    status: 'OPEN' | 'CLOSED';
+  }>;
+  score?: number;
+}
+
+export function mapToAdapterPayload(request: CreditReportRequest): CreditAdapterPayload {
+  return {
+    subjectReference: request.borrowerId,
+    social: request.ssn,
+    includeScore: request.includeScore ?? true,
+  };
+}
+
+export function mapFromAdapterResponse(
+  request: CreditReportRequest,
+  response: CreditAdapterResponse,
+): CreditReport {
+  return {
+    borrowerId: request.borrowerId,
+    tradelines: response.tradelines,
+    score: response.score,
+  };
+}

--- a/blp/apps/connectors/credit/src/server.ts
+++ b/blp/apps/connectors/credit/src/server.ts
@@ -1,1 +1,35 @@
-// Placeholder for ${f}.
+import express from 'express';
+import helmet from 'helmet';
+import { CreditService } from './service';
+import { CreditReportRequest } from './mappers';
+
+export function createServer(service = new CreditService()) {
+  const app = express();
+  app.use(helmet());
+  app.use(express.json());
+
+  app.post('/api/v1/credit/report', async (req, res) => {
+    try {
+      const request = req.body as CreditReportRequest;
+      const report = await service.getReport(request);
+      res.json(report);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      res.status(400).json({ error: message });
+    }
+  });
+
+  app.get('/health', (_req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  return app;
+}
+
+if (require.main === module) {
+  const port = process.env.PORT ? Number(process.env.PORT) : 3002;
+  createServer().listen(port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`Credit connector listening on ${port}`);
+  });
+}

--- a/blp/apps/connectors/credit/src/service.ts
+++ b/blp/apps/connectors/credit/src/service.ts
@@ -1,1 +1,45 @@
-// Placeholder for ${f}.
+import {
+  CreditAdapterPayload,
+  CreditAdapterResponse,
+  CreditReport,
+  CreditReportRequest,
+  mapFromAdapterResponse,
+  mapToAdapterPayload,
+} from './mappers';
+
+export interface CreditBureauAdapter {
+  pullReport(payload: CreditAdapterPayload): Promise<CreditAdapterResponse>;
+}
+
+class MockCreditBureauAdapter implements CreditBureauAdapter {
+  async pullReport(payload: CreditAdapterPayload): Promise<CreditAdapterResponse> {
+    const score = payload.includeScore
+      ? 720 - (payload.social.endsWith('9') ? 80 : 0)
+      : undefined;
+    return {
+      tradelines: [
+        {
+          creditor: 'Sample Bank',
+          balance: 15000,
+          status: 'OPEN',
+        },
+        {
+          creditor: 'Contoso Auto',
+          balance: 7000,
+          status: 'OPEN',
+        },
+      ],
+      score,
+    };
+  }
+}
+
+export class CreditService {
+  constructor(private readonly adapter: CreditBureauAdapter = new MockCreditBureauAdapter()) {}
+
+  async getReport(request: CreditReportRequest): Promise<CreditReport> {
+    const payload = mapToAdapterPayload(request);
+    const response = await this.adapter.pullReport(payload);
+    return mapFromAdapterResponse(request, response);
+  }
+}

--- a/blp/apps/connectors/credit/test/contract.pact.ts
+++ b/blp/apps/connectors/credit/test/contract.pact.ts
@@ -1,0 +1,59 @@
+import path from 'node:path';
+import { Matchers, Pact } from '@pact-foundation/pact';
+import request from 'supertest';
+import { createServer } from '../src/server';
+
+const provider = new Pact({
+  consumer: 'CoreAPI',
+  provider: 'CreditConnector',
+  dir: path.resolve(__dirname, '../../pacts'),
+  spec: 3,
+});
+
+describe('Credit connector Pact', () => {
+  beforeAll(() => provider.setup());
+  afterAll(() => provider.finalize());
+  afterEach(() => provider.verify());
+
+  it('produces a credit report', async () => {
+    await provider.addInteraction({
+      state: 'credit profile exists',
+      uponReceiving: 'a request for a credit report',
+      withRequest: {
+        method: 'POST',
+        path: '/api/v1/credit/report',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: {
+          borrowerId: 'abc',
+          ssn: '123-45-6789',
+          includeScore: true,
+        },
+      },
+      willRespondWith: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+        },
+        body: {
+          borrowerId: 'abc',
+          tradelines: Matchers.eachLike({
+            creditor: Matchers.like('Sample Bank'),
+            balance: Matchers.like(15000),
+            status: Matchers.like('OPEN'),
+          }),
+          score: Matchers.like(720),
+        },
+      },
+    });
+
+    const response = await request(createServer())
+      .post('/api/v1/credit/report')
+      .send({ borrowerId: 'abc', ssn: '123-45-6789', includeScore: true });
+
+    expect(response.status).toBe(200);
+    expect(response.body.borrowerId).toBe('abc');
+    expect(response.body.tradelines.length).toBeGreaterThan(0);
+  });
+});

--- a/blp/apps/connectors/credit/tsconfig.json
+++ b/blp/apps/connectors/credit/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "target": "ES2020",
+    "moduleResolution": "Node",
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["dist"]
+}

--- a/blp/apps/connectors/esign/package.json
+++ b/blp/apps/connectors/esign/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "esign",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "ts-node src/server.ts",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "helmet": "^7.0.0"
+  },
+  "devDependencies": {
+    "@pact-foundation/pact": "^12.0.0",
+    "@types/express": "^4.17.17",
+    "supertest": "^6.3.3",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.3.0",
+    "vitest": "^1.4.0"
+  }
+}

--- a/blp/apps/connectors/esign/src/server.ts
+++ b/blp/apps/connectors/esign/src/server.ts
@@ -1,1 +1,47 @@
-// Placeholder for ${f}.
+import express from 'express';
+import helmet from 'helmet';
+import { ESignService } from './service';
+
+export function createServer(service = new ESignService()) {
+  const app = express();
+  app.use(helmet());
+  app.use(express.json());
+
+  app.post('/api/v1/esign/envelopes', async (req, res) => {
+    try {
+      const summary = await service.createEnvelope(req.body);
+      res.status(201).json(summary);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      res.status(400).json({ error: message });
+    }
+  });
+
+  app.get('/api/v1/esign/envelopes/:envelopeId', async (req, res) => {
+    const envelope = await service.getEnvelope(req.params.envelopeId);
+    if (!envelope) {
+      res.status(404).json({ error: 'Envelope not found' });
+      return;
+    }
+    res.json(envelope);
+  });
+
+  app.post('/api/v1/esign/webhooks', async (req, res) => {
+    await service.acknowledgeWebhook(req.body);
+    res.status(202).json({ received: true });
+  });
+
+  app.get('/health', (_req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  return app;
+}
+
+if (require.main === module) {
+  const port = process.env.PORT ? Number(process.env.PORT) : 3004;
+  createServer().listen(port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`E-Sign connector listening on ${port}`);
+  });
+}

--- a/blp/apps/connectors/esign/src/service.ts
+++ b/blp/apps/connectors/esign/src/service.ts
@@ -1,1 +1,82 @@
-// Placeholder for ${f}.
+export interface EnvelopeParticipant {
+  name: string;
+  email: string;
+  role: 'BORROWER' | 'COBORROWER';
+  status?: 'PENDING' | 'SIGNED';
+}
+
+export interface CreateEnvelopeRequest {
+  envelopeId: string;
+  documentUrl: string;
+  participants: EnvelopeParticipant[];
+  callbackUrl: string;
+}
+
+export interface EnvelopeSummary {
+  envelopeId: string;
+  status: 'CREATED' | 'SENT' | 'COMPLETED';
+  participants: EnvelopeParticipant[];
+}
+
+export interface WebhookEvent {
+  envelopeId: string;
+  status: 'COMPLETED' | 'DECLINED';
+  reason?: string;
+}
+
+export interface ESignAdapter {
+  createEnvelope(request: CreateEnvelopeRequest): Promise<EnvelopeSummary>;
+  getEnvelope(envelopeId: string): Promise<EnvelopeSummary | undefined>;
+  acknowledgeWebhook(event: WebhookEvent): Promise<void>;
+}
+
+class MockESignAdapter implements ESignAdapter {
+  private readonly envelopes = new Map<string, EnvelopeSummary>();
+
+  async createEnvelope(request: CreateEnvelopeRequest): Promise<EnvelopeSummary> {
+    const summary: EnvelopeSummary = {
+      envelopeId: request.envelopeId,
+      status: 'SENT',
+      participants: request.participants.map((participant) => ({
+        ...participant,
+        status: 'PENDING',
+      })),
+    };
+    this.envelopes.set(summary.envelopeId, summary);
+    return summary;
+  }
+
+  async getEnvelope(envelopeId: string): Promise<EnvelopeSummary | undefined> {
+    return this.envelopes.get(envelopeId);
+  }
+
+  async acknowledgeWebhook(event: WebhookEvent): Promise<void> {
+    const envelope = this.envelopes.get(event.envelopeId);
+    if (!envelope) {
+      return;
+    }
+
+    envelope.status = event.status === 'COMPLETED' ? 'COMPLETED' : 'SENT';
+    envelope.participants = envelope.participants.map((participant) => ({
+      ...participant,
+      status: event.status === 'COMPLETED' ? 'SIGNED' : participant.status,
+    }));
+    this.envelopes.set(event.envelopeId, envelope);
+  }
+}
+
+export class ESignService {
+  constructor(private readonly adapter: ESignAdapter = new MockESignAdapter()) {}
+
+  createEnvelope(request: CreateEnvelopeRequest): Promise<EnvelopeSummary> {
+    return this.adapter.createEnvelope(request);
+  }
+
+  getEnvelope(envelopeId: string): Promise<EnvelopeSummary | undefined> {
+    return this.adapter.getEnvelope(envelopeId);
+  }
+
+  acknowledgeWebhook(event: WebhookEvent): Promise<void> {
+    return this.adapter.acknowledgeWebhook(event);
+  }
+}

--- a/blp/apps/connectors/esign/src/webhook.controller.ts
+++ b/blp/apps/connectors/esign/src/webhook.controller.ts
@@ -1,1 +1,10 @@
-// Placeholder for ${f}.
+import { Request, Response } from 'express';
+import { ESignService, WebhookEvent } from './service';
+
+export function createWebhookHandler(service = new ESignService()) {
+  return async (req: Request, res: Response) => {
+    const event = req.body as WebhookEvent;
+    await service.acknowledgeWebhook(event);
+    res.status(202).json({ received: true });
+  };
+}

--- a/blp/apps/connectors/esign/test/contract.pact.ts
+++ b/blp/apps/connectors/esign/test/contract.pact.ts
@@ -1,0 +1,69 @@
+import path from 'node:path';
+import { Matchers, Pact } from '@pact-foundation/pact';
+import request from 'supertest';
+import { createServer } from '../src/server';
+
+const provider = new Pact({
+  consumer: 'CoreAPI',
+  provider: 'ESignConnector',
+  dir: path.resolve(__dirname, '../../pacts'),
+  spec: 3,
+});
+
+describe('E-Sign connector Pact', () => {
+  beforeAll(() => provider.setup());
+  afterAll(() => provider.finalize());
+  afterEach(() => provider.verify());
+
+  it('creates envelopes for signing', async () => {
+    await provider.addInteraction({
+      state: 'a borrower requests e-signature',
+      uponReceiving: 'an envelope creation request',
+      withRequest: {
+        method: 'POST',
+        path: '/api/v1/esign/envelopes',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: {
+          envelopeId: 'env-1',
+          documentUrl: 'https://example.com/doc.pdf',
+          callbackUrl: 'https://example.com/hook',
+          participants: Matchers.eachLike({
+            name: 'Borrower',
+            email: 'borrower@example.com',
+            role: 'BORROWER',
+          }),
+        },
+      },
+      willRespondWith: {
+        status: 201,
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+        },
+        body: {
+          envelopeId: 'env-1',
+          status: Matchers.like('SENT'),
+          participants: Matchers.eachLike({
+            name: Matchers.like('Borrower'),
+            email: Matchers.like('borrower@example.com'),
+            role: Matchers.like('BORROWER'),
+            status: Matchers.like('PENDING'),
+          }),
+        },
+      },
+    });
+
+    const response = await request(createServer())
+      .post('/api/v1/esign/envelopes')
+      .send({
+        envelopeId: 'env-1',
+        documentUrl: 'https://example.com/doc.pdf',
+        callbackUrl: 'https://example.com/hook',
+        participants: [{ name: 'Borrower', email: 'borrower@example.com', role: 'BORROWER' }],
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.envelopeId).toBe('env-1');
+  });
+});

--- a/blp/apps/connectors/esign/tsconfig.json
+++ b/blp/apps/connectors/esign/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "target": "ES2020",
+    "moduleResolution": "Node",
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["dist"]
+}

--- a/blp/apps/connectors/package.json
+++ b/blp/apps/connectors/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "connectors",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "pnpm concurrently 'pnpm --filter ppe-adapter dev' 'pnpm --filter credit dev' 'pnpm --filter aus-gateway dev' 'pnpm --filter esign dev'"
+  }
+}

--- a/blp/apps/connectors/ppe-adapter/package.json
+++ b/blp/apps/connectors/ppe-adapter/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "ppe-adapter",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "ts-node src/server.ts",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "helmet": "^7.0.0"
+  },
+  "devDependencies": {
+    "@pact-foundation/pact": "^12.0.0",
+    "@types/express": "^4.17.17",
+    "supertest": "^6.3.3",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.3.0",
+    "vitest": "^1.4.0"
+  }
+}

--- a/blp/apps/connectors/ppe-adapter/src/mappers.ts
+++ b/blp/apps/connectors/ppe-adapter/src/mappers.ts
@@ -1,1 +1,47 @@
-// Placeholder for ${f}.
+export interface PPEEligibilityRequest {
+  borrowerId: string;
+  loanAmount: number;
+  propertyState: string;
+  occupancy: 'PRIMARY' | 'SECONDARY' | 'INVESTMENT';
+}
+
+export interface PPEAdapterPayload {
+  subjectId: string;
+  amount: number;
+  state: string;
+  occupancyCode: string;
+}
+
+export interface PPEEligibilityDecision {
+  borrowerId: string;
+  eligible: boolean;
+  maxLtv: number;
+  notes?: string;
+}
+
+export interface PPEAdapterResponse {
+  allowed: boolean;
+  maxLtv: number;
+  reason?: string;
+}
+
+export function mapToAdapterPayload(request: PPEEligibilityRequest): PPEAdapterPayload {
+  return {
+    subjectId: request.borrowerId,
+    amount: request.loanAmount,
+    state: request.propertyState,
+    occupancyCode: request.occupancy.slice(0, 3),
+  };
+}
+
+export function mapFromAdapterResponse(
+  request: PPEEligibilityRequest,
+  response: PPEAdapterResponse,
+): PPEEligibilityDecision {
+  return {
+    borrowerId: request.borrowerId,
+    eligible: response.allowed,
+    maxLtv: response.maxLtv,
+    notes: response.reason,
+  };
+}

--- a/blp/apps/connectors/ppe-adapter/src/server.ts
+++ b/blp/apps/connectors/ppe-adapter/src/server.ts
@@ -1,1 +1,35 @@
-// Placeholder for ${f}.
+import express from 'express';
+import helmet from 'helmet';
+import { PPEService } from './service';
+import { PPEEligibilityRequest } from './mappers';
+
+export function createServer(service = new PPEService()) {
+  const app = express();
+  app.use(helmet());
+  app.use(express.json());
+
+  app.post('/api/v1/ppe/eligibility', async (req, res) => {
+    try {
+      const payload = req.body as PPEEligibilityRequest;
+      const decision = await service.determineEligibility(payload);
+      res.json(decision);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      res.status(400).json({ error: message });
+    }
+  });
+
+  app.get('/health', (_req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  return app;
+}
+
+if (require.main === module) {
+  const port = process.env.PORT ? Number(process.env.PORT) : 3001;
+  createServer().listen(port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`PPE adapter listening on ${port}`);
+  });
+}

--- a/blp/apps/connectors/ppe-adapter/src/service.ts
+++ b/blp/apps/connectors/ppe-adapter/src/service.ts
@@ -1,1 +1,36 @@
-// Placeholder for ${f}.
+import {
+  PPEAdapterPayload,
+  PPEAdapterResponse,
+  PPEEligibilityDecision,
+  PPEEligibilityRequest,
+  mapFromAdapterResponse,
+  mapToAdapterPayload,
+} from './mappers';
+
+export interface PPEAdapter {
+  quote(request: PPEAdapterPayload): Promise<PPEAdapterResponse>;
+}
+
+class MockPPEAdapter implements PPEAdapter {
+  async quote(request: PPEAdapterPayload): Promise<PPEAdapterResponse> {
+    const baseLtv = request.occupancyCode === 'INV' ? 0.7 : 0.8;
+    const stateAdjustment = request.state === 'CA' ? -0.05 : 0;
+    const amountAdjustment = request.amount > 1_000_000 ? -0.05 : 0;
+    const maxLtv = Math.max(baseLtv + stateAdjustment + amountAdjustment, 0.5);
+    return {
+      allowed: maxLtv >= 0.6,
+      maxLtv,
+      reason: maxLtv < 0.6 ? 'High risk profile' : undefined,
+    };
+  }
+}
+
+export class PPEService {
+  constructor(private readonly adapter: PPEAdapter = new MockPPEAdapter()) {}
+
+  async determineEligibility(request: PPEEligibilityRequest): Promise<PPEEligibilityDecision> {
+    const payload = mapToAdapterPayload(request);
+    const response = await this.adapter.quote(payload);
+    return mapFromAdapterResponse(request, response);
+  }
+}

--- a/blp/apps/connectors/ppe-adapter/test/contract.pact.ts
+++ b/blp/apps/connectors/ppe-adapter/test/contract.pact.ts
@@ -1,1 +1,62 @@
-// Placeholder contract test.
+import path from 'node:path';
+import { Matchers, Pact } from '@pact-foundation/pact';
+import request from 'supertest';
+import { createServer } from '../src/server';
+
+const provider = new Pact({
+  consumer: 'CoreAPI',
+  provider: 'PPEAdapter',
+  dir: path.resolve(__dirname, '../../pacts'),
+  spec: 3,
+});
+
+describe('PPE Adapter Pact', () => {
+  beforeAll(() => provider.setup());
+  afterAll(() => provider.finalize());
+  afterEach(() => provider.verify());
+
+  it('returns an eligibility decision', async () => {
+    await provider.addInteraction({
+      state: 'borrower is active',
+      uponReceiving: 'a PPE eligibility request',
+      withRequest: {
+        method: 'POST',
+        path: '/api/v1/ppe/eligibility',
+        body: {
+          borrowerId: '123',
+          loanAmount: 500000,
+          propertyState: 'WA',
+          occupancy: 'PRIMARY',
+        },
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+      willRespondWith: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+        },
+        body: {
+          borrowerId: '123',
+          eligible: true,
+          maxLtv: Matchers.like(0.7),
+        },
+      },
+    });
+
+    const app = createServer();
+    const response = await request(app)
+      .post('/api/v1/ppe/eligibility')
+      .send({
+        borrowerId: '123',
+        loanAmount: 500000,
+        propertyState: 'WA',
+        occupancy: 'PRIMARY',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.borrowerId).toBe('123');
+    expect(response.body.eligible).toBe(true);
+  });
+});

--- a/blp/apps/connectors/ppe-adapter/tsconfig.json
+++ b/blp/apps/connectors/ppe-adapter/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "target": "ES2020",
+    "moduleResolution": "Node",
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["dist"]
+}

--- a/blp/apps/policy-bundle/build_bundle.py
+++ b/blp/apps/policy-bundle/build_bundle.py
@@ -1,4 +1,87 @@
-"""Placeholder script for building the OPA bundle."""
+"""Builds a signed OPA bundle for distribution."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import tarfile
+from pathlib import Path
+from typing import Iterable
+
+ROOT = Path(__file__).resolve().parent
+SRC = ROOT / "src"
+DEFAULT_OUTPUT = ROOT / "dist"
+
+
+def iter_policy_files() -> Iterable[Path]:
+  """Yield every Rego policy in the source tree."""
+
+  return SRC.glob("**/*.rego")
+
+
+def create_bundle(output_dir: Path, version: str) -> Path:
+  """Create the gzipped bundle and return the archive path."""
+
+  bundle_path = output_dir / f"policy-bundle-{version}.tar.gz"
+  bundle_path.parent.mkdir(parents=True, exist_ok=True)
+
+  with tarfile.open(bundle_path, "w:gz") as tar:
+    manifest = {
+      "revision": version,
+      "roots": [""],
+    }
+    manifest_bytes = json.dumps(manifest).encode("utf-8")
+    manifest_info = tarfile.TarInfo("/.manifest")
+    manifest_info.size = len(manifest_bytes)
+    tar.addfile(manifest_info, fileobj=_bytes_reader(manifest_bytes))
+
+    for policy in iter_policy_files():
+      relative = policy.relative_to(SRC)
+      data = policy.read_bytes()
+      info = tarfile.TarInfo(str(relative))
+      info.size = len(data)
+      tar.addfile(info, fileobj=_bytes_reader(data))
+
+  return bundle_path
+
+
+def _bytes_reader(data: bytes):
+  from io import BytesIO
+
+  return BytesIO(data)
+
+
+def sign_bundle(bundle_path: Path, signing_key: str) -> Path:
+  """Generate an HMAC signature for the bundle using the key provided."""
+
+  digest = hmac.new(signing_key.encode("utf-8"), digestmod=hashlib.sha256)
+  digest.update(bundle_path.read_bytes())
+  signature = base64.b64encode(digest.digest())
+  sig_path = bundle_path.with_suffix(bundle_path.suffix + ".sig")
+  sig_path.write_bytes(signature)
+  return sig_path
+
+
+def build(output: Path, version: str, signing_key: str | None) -> None:
+  """Create and optionally sign the policy bundle."""
+
+  bundle_path = create_bundle(output, version)
+  if signing_key:
+    sign_bundle(bundle_path, signing_key)
+  print(json.dumps({"bundle": str(bundle_path), "signed": bool(signing_key)}))
+
+
+def parse_args() -> argparse.Namespace:
+  parser = argparse.ArgumentParser(description="Build and sign OPA policy bundle")
+  parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+  parser.add_argument("--version", default="dev")
+  parser.add_argument("--signing-key", dest="signing_key")
+  return parser.parse_args()
+
 
 if __name__ == "__main__":
-    print("Build bundle placeholder")
+  args = parse_args()
+  build(args.output, args.version, args.signing_key)

--- a/blp/apps/policy-bundle/src/policy.rego
+++ b/blp/apps/policy-bundle/src/policy.rego
@@ -1,3 +1,108 @@
 package blp.policy
 
-# Placeholder policy module.
+default allow = false
+
+allow {
+  result := evaluate_contract
+  result.allow
+}
+
+deny[msg] {
+  result := evaluate_contract
+  msg := result.message
+  not result.allow
+}
+
+evaluate_contract = result {
+  input.contract == "trid"
+  result := evaluate_trid(input)
+}
+
+evaluate_contract = result {
+  input.contract == "esign"
+  result := evaluate_esign(input)
+}
+
+evaluate_contract = result {
+  input.contract == "lock"
+  result := evaluate_lock(input)
+}
+
+evaluate_contract = {"allow": false, "message": "unknown contract"} {
+  not input.contract
+}
+
+evaluate_contract = {"allow": false, "message": msg} {
+  input.contract
+  msg := sprintf("unsupported contract %q", [input.contract])
+  not any_contract_matches
+}
+
+any_contract_matches {
+  input.contract == "trid"
+}
+any_contract_matches {
+  input.contract == "esign"
+}
+any_contract_matches {
+  input.contract == "lock"
+}
+
+# TRID: CD must be delivered and waiting period observed.
+evaluate_trid(input) = {"allow": true} {
+  input.disclosure_delivered
+  input.waiting_period_days >= 3
+  input.borrower_acknowledged
+}
+
+evaluate_trid(input) = {"allow": false, "message": msg} {
+  not input.disclosure_delivered
+  msg := "closing disclosure must be delivered"
+}
+
+evaluate_trid(input) = {"allow": false, "message": msg} {
+  input.disclosure_delivered
+  input.waiting_period_days < 3
+  msg := "waiting period not met"
+}
+
+evaluate_trid(input) = {"allow": false, "message": msg} {
+  input.disclosure_delivered
+  input.waiting_period_days >= 3
+  not input.borrower_acknowledged
+  msg := "borrower acknowledgement required"
+}
+
+# E-Sign: all participants must consent and envelope status must be SENT/COMPLETED.
+evaluate_esign(input) = {"allow": true} {
+  consented := {p | p := input.participants[_]; p.consented}
+  count(consented) == count(input.participants)
+  input.envelope_status == "COMPLETED"
+}
+
+evaluate_esign(input) = {"allow": false, "message": "all participants must consent"} {
+  exists := {p | p := input.participants[_]; p.consented}
+  count(exists) != count(input.participants)
+}
+
+evaluate_esign(input) = {"allow": false, "message": msg} {
+  consented := {p | p := input.participants[_]; p.consented}
+  count(consented) == count(input.participants)
+  msg := "envelope must be completed"
+  input.envelope_status != "COMPLETED"
+}
+
+# Lock: ensure TRID window and pricing expiration.
+evaluate_lock(input) = {"allow": true} {
+  input.status == "ACTIVE"
+  input.expires_at >= input.current_date
+  not input.reprice_required
+}
+
+evaluate_lock(input) = {"allow": false, "message": "lock expired"} {
+  input.expires_at < input.current_date
+}
+
+evaluate_lock(input) = {"allow": false, "message": "reprice required"} {
+  input.reprice_required
+}

--- a/blp/apps/policy-bundle/src/policy_test.rego
+++ b/blp/apps/policy-bundle/src/policy_test.rego
@@ -1,0 +1,67 @@
+package blp.policy
+
+import data.blp.policy
+
+trid_allows_when_waiting_period_satisfied {
+  allow with input as {
+    "contract": "trid",
+    "disclosure_delivered": true,
+    "waiting_period_days": 3,
+    "borrower_acknowledged": true,
+  }
+}
+
+trid_denies_when_waiting_period_short {
+  not allow with input as {
+    "contract": "trid",
+    "disclosure_delivered": true,
+    "waiting_period_days": 2,
+    "borrower_acknowledged": true,
+  }
+  deny[msg] with input as {
+    "contract": "trid",
+    "disclosure_delivered": true,
+    "waiting_period_days": 2,
+    "borrower_acknowledged": true,
+  }
+  msg == "waiting period not met"
+}
+
+esign_requires_consent {
+  not allow with input as {
+    "contract": "esign",
+    "participants": [
+      {"name": "Borrower", "consented": true},
+      {"name": "Co", "consented": false},
+    ],
+    "envelope_status": "COMPLETED",
+  }
+}
+
+esign_allows_when_complete {
+  allow with input as {
+    "contract": "esign",
+    "participants": [
+      {"name": "Borrower", "consented": true},
+    ],
+    "envelope_status": "COMPLETED",
+  }
+}
+
+lock_denies_on_expiration {
+  not allow with input as {
+    "contract": "lock",
+    "status": "ACTIVE",
+    "expires_at": "2024-01-01",
+    "current_date": "2024-01-02",
+    "reprice_required": false,
+  }
+  deny[msg] with input as {
+    "contract": "lock",
+    "status": "ACTIVE",
+    "expires_at": "2024-01-01",
+    "current_date": "2024-01-02",
+    "reprice_required": false,
+  }
+  msg == "lock expired"
+}

--- a/blp/apps/worker/package.json
+++ b/blp/apps/worker/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "worker",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "ts-node src/index.ts",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@temporalio/worker": "^1.9.0",
+    "@temporalio/workflow": "^1.9.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.3.0",
+    "vitest": "^1.4.0"
+  }
+}

--- a/blp/apps/worker/src/activities.ts
+++ b/blp/apps/worker/src/activities.ts
@@ -1,1 +1,93 @@
-// Placeholder for ${f}.
+export interface TridComplianceInput {
+  disclosureDelivered: boolean;
+  waitingPeriodDays: number;
+  borrowerAcknowledged: boolean;
+}
+
+export interface TridComplianceResult {
+  compliant: boolean;
+  message?: string;
+}
+
+export interface EsignEnvelopeInput {
+  envelopeId: string;
+  participants: Array<{ name: string; email: string }>;
+  documentUrl: string;
+}
+
+export interface EsignEnvelopeResult {
+  envelopeId: string;
+  sent: boolean;
+  recipients: Array<{ name: string; email: string }>;
+}
+
+export interface LockLifecycleInput {
+  lockId: string;
+  expiresAt: Date;
+  repriceRequired?: boolean;
+}
+
+export interface LockLifecycleResult {
+  lockId: string;
+  status: 'ACTIVE' | 'EXPIRED' | 'REPRICE_REQUIRED';
+  expiresAt: Date;
+}
+
+const inMemoryEnvelopes = new Map<string, EsignEnvelopeResult>();
+const lockStore = new Map<string, LockLifecycleResult>();
+
+export async function validateTridCompliance(
+  input: TridComplianceInput,
+): Promise<TridComplianceResult> {
+  if (!input.disclosureDelivered) {
+    return { compliant: false, message: 'Closing disclosure not delivered' };
+  }
+
+  if (input.waitingPeriodDays < 3) {
+    return { compliant: false, message: 'Mandatory waiting period not satisfied' };
+  }
+
+  if (!input.borrowerAcknowledged) {
+    return { compliant: false, message: 'Borrower acknowledgement missing' };
+  }
+
+  return { compliant: true };
+}
+
+export async function createEsignEnvelope(
+  input: EsignEnvelopeInput,
+): Promise<EsignEnvelopeResult> {
+  const envelope: EsignEnvelopeResult = {
+    envelopeId: input.envelopeId,
+    sent: true,
+    recipients: input.participants,
+  };
+  inMemoryEnvelopes.set(envelope.envelopeId, envelope);
+  return envelope;
+}
+
+export async function fetchEsignEnvelope(envelopeId: string): Promise<EsignEnvelopeResult | undefined> {
+  return inMemoryEnvelopes.get(envelopeId);
+}
+
+export async function upsertLockState(input: LockLifecycleInput): Promise<LockLifecycleResult> {
+  let status: LockLifecycleResult['status'] = 'ACTIVE';
+
+  if (input.expiresAt.getTime() < Date.now()) {
+    status = 'EXPIRED';
+  } else if (input.repriceRequired) {
+    status = 'REPRICE_REQUIRED';
+  }
+
+  const result: LockLifecycleResult = {
+    lockId: input.lockId,
+    status,
+    expiresAt: input.expiresAt,
+  };
+  lockStore.set(result.lockId, result);
+  return result;
+}
+
+export async function readLockState(lockId: string): Promise<LockLifecycleResult | undefined> {
+  return lockStore.get(lockId);
+}

--- a/blp/apps/worker/src/index.ts
+++ b/blp/apps/worker/src/index.ts
@@ -1,1 +1,21 @@
-// Placeholder for ${f}.
+import { Worker } from '@temporalio/worker';
+import * as activities from './activities';
+import * as workflows from './workflows';
+
+export async function runWorker() {
+  const worker = await Worker.create({
+    workflowsPath: require.resolve('./workflows'),
+    activities,
+    taskQueue: process.env.TEMPORAL_TASK_QUEUE ?? 'blp.default',
+  });
+
+  await worker.run();
+}
+
+if (require.main === module) {
+  runWorker().catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error('Temporal worker failed to start', error);
+    process.exitCode = 1;
+  });
+}

--- a/blp/apps/worker/src/workflows.ts
+++ b/blp/apps/worker/src/workflows.ts
@@ -1,1 +1,97 @@
-// Placeholder for ${f}.
+import { ApplicationFailure, proxyActivities } from '@temporalio/workflow';
+import type {
+  EsignEnvelopeInput,
+  EsignEnvelopeResult,
+  LockLifecycleInput,
+  LockLifecycleResult,
+  TridComplianceInput,
+  TridComplianceResult,
+} from './activities';
+
+type ActivityProxy = {
+  validateTridCompliance(input: TridComplianceInput): Promise<TridComplianceResult>;
+  createEsignEnvelope(input: EsignEnvelopeInput): Promise<EsignEnvelopeResult>;
+  fetchEsignEnvelope(envelopeId: string): Promise<EsignEnvelopeResult | undefined>;
+  upsertLockState(input: LockLifecycleInput): Promise<LockLifecycleResult>;
+  readLockState(lockId: string): Promise<LockLifecycleResult | undefined>;
+};
+
+function createProxy(): ActivityProxy {
+  try {
+    return proxyActivities<ActivityProxy>({
+      startToCloseTimeout: '30 seconds',
+    });
+  } catch (error) {
+    // Outside of a Temporal workflow runtime (e.g. unit tests) the proxy
+    // creation will throw. Fallback to directly invoking the activity
+    // implementations.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const fallback = require('./activities') as typeof import('./activities');
+    return {
+      validateTridCompliance: fallback.validateTridCompliance,
+      createEsignEnvelope: fallback.createEsignEnvelope,
+      fetchEsignEnvelope: fallback.fetchEsignEnvelope,
+      upsertLockState: fallback.upsertLockState,
+      readLockState: fallback.readLockState,
+    };
+  }
+}
+
+export const activities: ActivityProxy = createProxy();
+
+export interface TridWorkflowInput extends TridComplianceInput {
+  loanId: string;
+}
+
+export function ensureTridCompliant(result: TridComplianceResult): TridComplianceResult {
+  if (!result.compliant) {
+    throw ApplicationFailure.nonRetryable(result.message ?? 'TRID compliance failed');
+  }
+  return result;
+}
+
+export async function tridWorkflow(input: TridWorkflowInput): Promise<TridComplianceResult> {
+  const result = await activities.validateTridCompliance(input);
+  return ensureTridCompliant(result);
+}
+
+export interface EsignWorkflowInput extends EsignEnvelopeInput {
+  waitForCompletion?: boolean;
+}
+
+export function ensureEnvelopePersisted(
+  envelopeId: string,
+  persisted?: EsignEnvelopeResult,
+): EsignEnvelopeResult {
+  if (!persisted) {
+    throw ApplicationFailure.nonRetryable('Envelope not found after creation');
+  }
+  return persisted;
+}
+
+export async function esignWorkflow(input: EsignWorkflowInput): Promise<EsignEnvelopeResult> {
+  const envelope = await activities.createEsignEnvelope(input);
+
+  if (input.waitForCompletion) {
+    const persisted = await activities.fetchEsignEnvelope(envelope.envelopeId);
+    return ensureEnvelopePersisted(envelope.envelopeId, persisted);
+  }
+
+  return envelope;
+}
+
+export interface LockWorkflowInput extends LockLifecycleInput {
+  pollIntervalMs?: number;
+}
+
+export function ensureLockActive(state: LockLifecycleResult): LockLifecycleResult {
+  if (state.status === 'REPRICE_REQUIRED' || state.status === 'EXPIRED') {
+    throw ApplicationFailure.nonRetryable(`Lock ${state.lockId} is ${state.status}`);
+  }
+  return state;
+}
+
+export async function lockLifecycleWorkflow(input: LockWorkflowInput): Promise<LockLifecycleResult> {
+  const state = await activities.upsertLockState(input);
+  return ensureLockActive(state);
+}

--- a/blp/apps/worker/test/activities.test.ts
+++ b/blp/apps/worker/test/activities.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createEsignEnvelope,
+  fetchEsignEnvelope,
+  upsertLockState,
+  validateTridCompliance,
+} from '../src/activities';
+
+describe('worker activities', () => {
+  it('validates TRID compliance', async () => {
+    const compliant = await validateTridCompliance({
+      disclosureDelivered: true,
+      waitingPeriodDays: 3,
+      borrowerAcknowledged: true,
+    });
+    expect(compliant.compliant).toBe(true);
+  });
+
+  it('creates and fetches envelopes', async () => {
+    await createEsignEnvelope({
+      envelopeId: 'env-123',
+      documentUrl: 'https://example.com/doc.pdf',
+      participants: [{ name: 'Borrower', email: 'borrower@example.com' }],
+    });
+
+    const envelope = await fetchEsignEnvelope('env-123');
+    expect(envelope?.envelopeId).toBe('env-123');
+  });
+
+  it('updates lock state', async () => {
+    const result = await upsertLockState({
+      lockId: 'lock-1',
+      expiresAt: new Date(Date.now() + 10_000),
+    });
+    expect(result.status).toBe('ACTIVE');
+  });
+});

--- a/blp/apps/worker/test/workflows.test.ts
+++ b/blp/apps/worker/test/workflows.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EsignWorkflowInput,
+  LockWorkflowInput,
+  TridWorkflowInput,
+  esignWorkflow,
+  lockLifecycleWorkflow,
+  tridWorkflow,
+} from '../src/workflows';
+
+describe('workflows', () => {
+  it('approves TRID when compliant', async () => {
+    const input: TridWorkflowInput = {
+      loanId: 'loan-1',
+      disclosureDelivered: true,
+      waitingPeriodDays: 3,
+      borrowerAcknowledged: true,
+    };
+
+    // Should not throw when compliant
+    await expect(tridWorkflow(input)).resolves.toMatchObject({ compliant: true });
+  });
+
+  it('creates an e-sign envelope', async () => {
+    const input: EsignWorkflowInput = {
+      envelopeId: 'env-1',
+      documentUrl: 'https://example.com/doc.pdf',
+      participants: [{ name: 'Borrower', email: 'borrower@example.com' }],
+    };
+
+    const result = await esignWorkflow(input);
+    expect(result.envelopeId).toBe('env-1');
+  });
+
+  it('persists lock state', async () => {
+    const input: LockWorkflowInput = {
+      lockId: 'lock-1',
+      expiresAt: new Date(Date.now() + 60_000),
+    };
+
+    const result = await lockLifecycleWorkflow(input);
+    expect(result.status).toBe('ACTIVE');
+  });
+});

--- a/blp/apps/worker/tsconfig.json
+++ b/blp/apps/worker/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "target": "ES2020",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["dist"]
+}

--- a/blp/infra/docker-compose.dev.yml
+++ b/blp/infra/docker-compose.dev.yml
@@ -1,6 +1,153 @@
-version: "3.9"
+version: '3.9'
 
 services:
-  placeholder:
-    image: alpine:3
-    command: ["sleep", "infinity"]
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: blp
+      POSTGRES_PASSWORD: blp
+      POSTGRES_DB: blp
+    ports:
+      - '5432:5432'
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7
+    ports:
+      - '6379:6379'
+
+  redpanda:
+    image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+    command:
+      - redpanda
+      - start
+      - --smp
+      - '1'
+      - --memory
+      - 1G
+      - --overprovisioned
+      - --node-id
+      - '0'
+      - --kafka-addr
+      - PLAINTEXT://0.0.0.0:9092,OUTSIDE://0.0.0.0:19092
+      - --advertise-kafka-addr
+      - PLAINTEXT://redpanda:9092,OUTSIDE://localhost:19092
+    ports:
+      - '9092:9092'
+      - '19092:19092'
+    volumes:
+      - redpanda-data:/var/lib/redpanda/data
+
+  temporal:
+    image: temporalio/auto-setup:1.21.0
+    environment:
+      - DB=postgresql
+      - DB_PORT=5432
+      - POSTGRES_USER=temporal
+      - POSTGRES_PWD=temporal
+      - POSTGRES_SEEDS=postgres
+    depends_on:
+      - postgres
+    ports:
+      - '7233:7233'
+
+  temporal-ui:
+    image: temporalio/ui:2.20.0
+    environment:
+      - TEMPORAL_ADDRESS=temporal:7233
+    ports:
+      - '8080:8080'
+    depends_on:
+      - temporal
+
+  opa:
+    image: openpolicyagent/opa:0.59.0
+    command: ['run', '--server', '--addr=0.0.0.0:8181', '/policy/policy-bundle-dev.tar.gz']
+    ports:
+      - '8181:8181'
+    volumes:
+      - ./../apps/policy-bundle/dist:/policy
+
+  minio:
+    image: minio/minio:RELEASE.2023-09-07T02-05-02Z
+    environment:
+      MINIO_ROOT_USER: blp
+      MINIO_ROOT_PASSWORD: blpsecret
+    command: server /data --console-address :9001
+    ports:
+      - '9000:9000'
+      - '9001:9001'
+    volumes:
+      - minio-data:/data
+
+  clamav:
+    image: clamav/clamav:stable
+    ports:
+      - '3310:3310'
+
+  connectors-ppe:
+    image: node:20
+    working_dir: /app
+    command: bash -lc "corepack enable && pnpm install && pnpm --filter ppe-adapter dev"
+    volumes:
+      - ..:/app
+    environment:
+      - PORT=3001
+    ports:
+      - '3001:3001'
+    depends_on:
+      - postgres
+      - redis
+
+  connectors-credit:
+    image: node:20
+    working_dir: /app
+    command: bash -lc "corepack enable && pnpm install && pnpm --filter credit dev"
+    volumes:
+      - ..:/app
+    environment:
+      - PORT=3002
+    ports:
+      - '3002:3002'
+
+  connectors-aus:
+    image: node:20
+    working_dir: /app
+    command: bash -lc "corepack enable && pnpm install && pnpm --filter aus-gateway dev"
+    volumes:
+      - ..:/app
+    environment:
+      - PORT=3003
+    ports:
+      - '3003:3003'
+
+  connectors-esign:
+    image: node:20
+    working_dir: /app
+    command: bash -lc "corepack enable && pnpm install && pnpm --filter esign dev"
+    volumes:
+      - ..:/app
+    environment:
+      - PORT=3004
+    ports:
+      - '3004:3004'
+
+  worker:
+    image: node:20
+    working_dir: /app
+    command: bash -lc "corepack enable && pnpm install && pnpm --filter worker dev"
+    volumes:
+      - ..:/app
+    environment:
+      TEMPORAL_ADDRESS: temporal:7233
+      TEMPORAL_TASK_QUEUE: blp.default
+    depends_on:
+      - temporal
+      - redis
+      - postgres
+
+volumes:
+  postgres-data:
+  redpanda-data:
+  minio-data:

--- a/blp/pnpm-workspace.yaml
+++ b/blp/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "apps/*"
+  - "apps/connectors/*"
   - "libs/*"

--- a/blp/tsconfig.base.json
+++ b/blp/tsconfig.base.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- replace connector placeholders with Express services, mock adapters, mappers, and Pact contract tests plus package metadata
- author TRID, e-sign, and lock policies with Rego tests and build script for signed bundles
- implement Temporal worker workflows/activities and expand docker-compose stack and README instructions for local dev

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d81a79bbc883329a2fdbb06e17d7b7