### PR TITLE
Adjust ValidationError schema message type

### DIFF
--- a/blp/docs/APIs/core-api.yaml
+++ b/blp/docs/APIs/core-api.yaml
@@ -339,3 +339,39 @@ components:
         createdAt:
           type: string
           format: date-time
+    ErrorResponse:
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code.
+        message:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                type: string
+          description: Human-readable error message or collection of messages.
+        details:
+          type: object
+          additionalProperties: true
+          description: Optional additional data about the error.
+    ValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+        - type: object
+          required: [message]
+          properties:
+            message:
+              type: array
+              items:
+                type: string
+              description: One or more validation error messages.
+            fieldErrors:
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  type: string
+              description: Field-specific validation messages keyed by field name.


### PR DESCRIPTION
## Summary
- add an ErrorResponse schema that allows the message to be a string or an array
- update ValidationError to extend ErrorResponse while constraining messages to arrays and documenting field-level errors

## Testing
- npx @redocly/cli lint docs/APIs/core-api.yaml

------
https://chatgpt.com/codex/tasks/task_e_68d821c6d5d883328a0f549379c8837f