### PR TITLE
Add TCPA compliance policies and bundle packaging

### DIFF
--- a/blp/apps/policy-bundle/src/policy.rego
+++ b/blp/apps/policy-bundle/src/policy.rego
@@ -28,6 +28,21 @@ evaluate_contract = result {
   result := evaluate_lock(input)
 }
 
+evaluate_contract = result {
+  input.contract == "tcpa"
+  result := evaluate_tcpa(input)
+}
+
+evaluate_contract = result {
+  input.contract == "recording"
+  result := evaluate_recording(input)
+}
+
+evaluate_contract = result {
+  input.contract == "stage_transition"
+  result := evaluate_stage_transition(input)
+}
+
 evaluate_contract = {"allow": false, "message": "unknown contract"} {
   not input.contract
 }
@@ -46,6 +61,15 @@ any_contract_matches {
 }
 any_contract_matches {
   input.contract == "lock"
+}
+any_contract_matches {
+  input.contract == "tcpa"
+}
+any_contract_matches {
+  input.contract == "recording"
+}
+any_contract_matches {
+  input.contract == "stage_transition"
 }
 
 # TRID: CD must be delivered and waiting period observed.
@@ -105,4 +129,195 @@ evaluate_lock(input) = {"allow": false, "message": "lock expired"} {
 
 evaluate_lock(input) = {"allow": false, "message": "reprice required"} {
   input.reprice_required
+}
+
+# TCPA: ensure required consent is collected for every jurisdiction and the
+# borrower has not opted out of contact attempts.
+evaluate_tcpa(input) = {"allow": true} {
+  not input.do_not_call
+  required := tcpa_required_jurisdictions(input)
+  consents := communication_consents(input)
+  missing := {j | j := required[_]; not has_consent(consents, j)}
+  count(missing) == 0
+}
+
+evaluate_tcpa(input) = {"allow": false, "message": "party is on the do not call list"} {
+  input.do_not_call
+}
+
+evaluate_tcpa(input) = {"allow": false, "message": msg} {
+  not input.do_not_call
+  required := tcpa_required_jurisdictions(input)
+  consents := communication_consents(input)
+  missing := [j | j := required[_]; not has_consent(consents, j)]
+  count(missing) > 0
+  msg := sprintf("missing consent for %v", [sort(missing)])
+}
+
+tcpa_required_jurisdictions(input) = required {
+  base := {"federal"}
+  states := jurisdiction_set(object.get(input, "jurisdictions", []))
+  required := base | states
+}
+
+# Recording: two-party jurisdictions require affirmative consent for recording
+# on top of the universal federal consent requirement.
+evaluate_recording(input) = {"allow": true} {
+  not input.recording_enabled
+}
+
+evaluate_recording(input) = {"allow": true} {
+  input.recording_enabled
+  consents := recording_consents(input)
+  required := recording_required_jurisdictions(input)
+  missing := {j | j := required[_]; not has_consent(consents, j)}
+  count(missing) == 0
+}
+
+evaluate_recording(input) = {"allow": false, "message": msg} {
+  input.recording_enabled
+  consents := recording_consents(input)
+  required := recording_required_jurisdictions(input)
+  missing := [j | j := required[_]; not has_consent(consents, j)]
+  count(missing) > 0
+  msg := sprintf("missing recording consent for %v", [sort(missing)])
+}
+
+recording_required_jurisdictions(input) = required {
+  base := {"federal"}
+  states := jurisdiction_set(object.get(input, "jurisdictions", []))
+  required := base | {s | s := states[_]; recording_two_party_state(s)}
+}
+
+recording_two_party_state(state) {
+  two_party_states[state]
+}
+
+two_party_states := {
+  "ca": true,
+  "ct": true,
+  "fl": true,
+  "il": true,
+  "md": true,
+  "ma": true,
+  "mi": true,
+  "mt": true,
+  "nv": true,
+  "nh": true,
+  "pa": true,
+  "wa": true,
+}
+
+# Workflow stage transitions enforce sequential movement and gate completion.
+evaluate_stage_transition(input) = {"allow": true} {
+  current := input.current_stage
+  target := input.target_stage
+  valid_stage(current)
+  valid_stage(target)
+  progression_allowed(current, target)
+  missing := stage_missing_requirements(input, target)
+  count(missing) == 0
+}
+
+evaluate_stage_transition(input) = {"allow": true} {
+  current := input.current_stage
+  target := input.target_stage
+  valid_stage(current)
+  target == current
+}
+
+evaluate_stage_transition(input) = {"allow": false, "message": msg} {
+  current := input.current_stage
+  target := input.target_stage
+  not valid_stage(current)
+  msg := sprintf("unknown workflow stage %q", [current])
+}
+
+evaluate_stage_transition(input) = {"allow": false, "message": msg} {
+  target := input.target_stage
+  not valid_stage(target)
+  msg := sprintf("unknown workflow stage %q", [target])
+}
+
+evaluate_stage_transition(input) = {"allow": false, "message": msg} {
+  current := input.current_stage
+  target := input.target_stage
+  valid_stage(current)
+  valid_stage(target)
+  not progression_allowed(current, target)
+  msg := sprintf("invalid transition from %q to %q", [current, target])
+}
+
+evaluate_stage_transition(input) = {"allow": false, "message": msg} {
+  current := input.current_stage
+  target := input.target_stage
+  valid_stage(current)
+  valid_stage(target)
+  progression_allowed(current, target)
+  missing := stage_missing_requirements(input, target)
+  count(missing) > 0
+  msg := sprintf("workflow requirements missing: %v", [missing])
+}
+
+progression_allowed(current, target) {
+  stage_index(target) == stage_index(current) + 1
+}
+
+stage_index(stage) = index {
+  index := stage_index_map[stage]
+}
+
+stage_index_map := {
+  "lead": 0,
+  "application": 1,
+  "processing": 2,
+  "underwriting": 3,
+  "closing": 4,
+  "funded": 5,
+}
+
+valid_stage(stage) {
+  stage_index_map[stage]
+}
+
+stage_missing_requirements(input, target) = missing {
+  requirements := object.get(stage_requirement_map, target, [])
+  conditions := object.get(input, "conditions", {})
+  missing := [r |
+    r := requirements[_]
+    not condition_complete(conditions, r)
+  ]
+}
+
+condition_complete(conditions, requirement) {
+  value := conditions[requirement]
+  value == true
+}
+
+stage_requirement_map := {
+  "lead": [],
+  "application": ["application_complete"],
+  "processing": ["documents_received"],
+  "underwriting": ["documents_received", "credit_verified"],
+  "closing": ["clear_to_close", "disclosures_signed"],
+  "funded": ["clear_to_close", "funding_authorized"],
+}
+
+communication_consents(input) = object.get(input, "communication_consents", {})
+
+recording_consents(input) = object.get(input, "recording_consents", {})
+
+jurisdiction_set(items) = {normalize_jurisdiction(item) | item := items[_]}
+
+normalize_jurisdiction(item) = lower(item) {
+  is_string(item)
+}
+
+normalize_jurisdiction(item) = item {
+  not is_string(item)
+}
+
+has_consent(consents, jurisdiction) {
+  value := consents[jurisdiction]
+  value == true
 }

--- a/blp/apps/policy-bundle/src/tests/policy_test.rego
+++ b/blp/apps/policy-bundle/src/tests/policy_test.rego
@@ -1,3 +1,102 @@
 package blp.policy
 
-# Placeholder tests.
+import data.blp.policy as policy
+
+test_tcpa_allows_when_all_consents_present {
+  result := policy.evaluate_tcpa({
+    "jurisdictions": ["CA", "NV"],
+    "communication_consents": {
+      "federal": true,
+      "ca": true,
+      "nv": true,
+    },
+    "do_not_call": false,
+  })
+  result.allow
+}
+
+test_tcpa_blocks_when_missing_state_consent {
+  result := policy.evaluate_tcpa({
+    "jurisdictions": ["CA"],
+    "communication_consents": {
+      "federal": true,
+    },
+    "do_not_call": false,
+  })
+  not result.allow
+  result.message == "missing consent for [\"ca\"]"
+}
+
+test_tcpa_blocks_do_not_call_flag {
+  result := policy.evaluate_tcpa({
+    "jurisdictions": ["CA"],
+    "communication_consents": {
+      "federal": true,
+      "ca": true,
+    },
+    "do_not_call": true,
+  })
+  not result.allow
+  result.message == "party is on the do not call list"
+}
+
+test_recording_allows_one_party_state_without_extra_consent {
+  result := policy.evaluate_recording({
+    "recording_enabled": true,
+    "jurisdictions": ["TX"],
+    "recording_consents": {
+      "federal": true,
+    },
+  })
+  result.allow
+}
+
+test_recording_requires_dual_party_consent {
+  result := policy.evaluate_recording({
+    "recording_enabled": true,
+    "jurisdictions": ["CA"],
+    "recording_consents": {
+      "federal": true,
+    },
+  })
+  not result.allow
+  result.message == "missing recording consent for [\"ca\"]"
+}
+
+test_stage_transition_requires_sequential_order {
+  result := policy.evaluate_stage_transition({
+    "current_stage": "lead",
+    "target_stage": "underwriting",
+    "conditions": {
+      "application_complete": true,
+      "documents_received": true,
+      "credit_verified": true,
+    },
+  })
+  not result.allow
+  result.message == "invalid transition from \"lead\" to \"underwriting\""
+}
+
+test_stage_transition_requires_gates {
+  result := policy.evaluate_stage_transition({
+    "current_stage": "processing",
+    "target_stage": "underwriting",
+    "conditions": {
+      "documents_received": true,
+    },
+  })
+  not result.allow
+  result.message == "workflow requirements missing: [\"credit_verified\"]"
+}
+
+test_stage_transition_succeeds_when_gates_complete {
+  result := policy.evaluate_stage_transition({
+    "current_stage": "application",
+    "target_stage": "processing",
+    "conditions": {
+      "application_complete": true,
+      "documents_received": true,
+    },
+  })
+  result.allow
+}


### PR DESCRIPTION
## Summary
- implement TCPA, call recording, and workflow stage transition policies in the Rego bundle
- add unit tests covering consent combinations and workflow gate behavior
- enhance the bundle builder to run tests, emit distribution metadata, and support CI usage

## Testing
- opa test blp/apps/policy-bundle/src *(fails: opa not installed in environment)*
- python blp/apps/policy-bundle/build_bundle.py --skip-tests


------
https://chatgpt.com/codex/tasks/task_e_68d82a9a982483328a26ba5360742508