### PR TITLE
chore(ci): expand workflows for core, rules, and connectors

### DIFF
--- a/blp/.github/workflows/ci-connectors.yml
+++ b/blp/.github/workflows/ci-connectors.yml
@@ -41,13 +41,25 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
           run_install: false
+
+      - name: Determine pnpm store path
+        id: pnpm-cache
+        run: |
+          echo "store-path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store-path }}
+          key: ${{ runner.os }}-connectors-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-connectors-pnpm-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile=false
@@ -98,13 +110,25 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
           run_install: false
+
+      - name: Determine pnpm store path
+        id: pnpm-cache
+        run: |
+          echo "store-path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store-path }}
+          key: ${{ runner.os }}-connectors-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-connectors-pnpm-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile=false
@@ -136,10 +160,81 @@ jobs:
           path: pact-reports/${{ matrix.connector }}
           if-no-files-found: warn
 
+  lint:
+    name: Connector linting
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    strategy:
+      fail-fast: false
+      matrix:
+        connector: [aus-gateway, credit, esign, ppe-adapter]
+    env:
+      PNPM_HOME: ~/.pnpm
+      PATH: ${{ env.PNPM_HOME }}:${{ env.PATH }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Determine pnpm store path
+        id: pnpm-cache
+        run: |
+          echo "store-path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store-path }}
+          key: ${{ runner.os }}-connectors-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-connectors-pnpm-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile=false
+
+      - name: Run lint checks
+        run: |
+          set -o pipefail
+          REPORT_DIR=lint-reports/${{ matrix.connector }}
+          mkdir -p "$REPORT_DIR"
+          LOG_FILE="$REPORT_DIR/lint.log"
+          if pnpm --filter ${{ matrix.connector }}... lint 2>&1 | tee "$LOG_FILE"; then
+            echo "Lint completed for ${{ matrix.connector }}" | tee -a "$LOG_FILE"
+          elif [ -f apps/connectors/${{ matrix.connector }}/package.json ]; then
+            if pnpm --dir apps/connectors/${{ matrix.connector }} lint 2>&1 | tee "$LOG_FILE"; then
+              echo "Lint completed for ${{ matrix.connector }}" | tee -a "$LOG_FILE"
+            else
+              echo "Lint failed for ${{ matrix.connector }}" | tee -a "$LOG_FILE"
+              exit 1
+            fi
+          else
+            echo "No lint command found for ${{ matrix.connector }}" | tee "$LOG_FILE"
+          fi
+
+      - name: Upload lint logs
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: connectors-lint-${{ matrix.connector }}
+          path: lint-reports/${{ matrix.connector }}
+          if-no-files-found: warn
+
   docker-images:
     name: Build connector images
     runs-on: ubuntu-latest
-    needs: pact-verification
+    needs:
+      - pact-verification
+      - lint
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/blp/.github/workflows/ci-core.yml
+++ b/blp/.github/workflows/ci-core.yml
@@ -37,13 +37,25 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
           run_install: false
+
+      - name: Determine pnpm store path
+        id: pnpm-cache
+        run: |
+          echo "store-path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store-path }}
+          key: ${{ runner.os }}-core-api-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-core-api-pnpm-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile=false
@@ -102,6 +114,19 @@ jobs:
         with:
           version: 9
           run_install: false
+
+      - name: Determine pnpm store path
+        id: pnpm-cache
+        run: |
+          echo "store-path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store-path }}
+          key: ${{ runner.os }}-core-api-security-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-core-api-security-pnpm-
 
       - name: Install dependencies (audit context)
         run: pnpm install --frozen-lockfile=false

--- a/blp/.github/workflows/ci-rules.yml
+++ b/blp/.github/workflows/ci-rules.yml
@@ -38,8 +38,19 @@ jobs:
 
       - name: Install dependencies
         run: |
+          set -euo pipefail
           python -m pip install --upgrade pip
-          if [ -f apps/rules-engine/requirements-dev.txt ]; then
+
+          if [ -f poetry.lock ] || { [ -f pyproject.toml ] && grep -q "\\[tool.poetry\\]" pyproject.toml; }; then
+            python -m pip install poetry
+            poetry install --no-interaction --with dev --no-root || poetry install --no-interaction
+          elif [ -f apps/rules-engine/poetry.lock ] || { [ -f apps/rules-engine/pyproject.toml ] && grep -q "\\[tool.poetry\\]" apps/rules-engine/pyproject.toml; }; then
+            python -m pip install poetry
+            (
+              cd apps/rules-engine
+              poetry install --no-interaction --with dev --no-root || poetry install --no-interaction
+            )
+          elif [ -f apps/rules-engine/requirements-dev.txt ]; then
             pip install -r apps/rules-engine/requirements-dev.txt
           elif [ -f apps/rules-engine/requirements.txt ]; then
             pip install -r apps/rules-engine/requirements.txt


### PR DESCRIPTION
## Summary
- add pnpm store caching to the core API workflow alongside the existing lint, test, build, SDK generation, security scans, and image builds
- allow the rules engine workflow to choose Poetry or pip so pytest, regression, mypy, and Docker stages work regardless of dependency manager
- extend the connectors workflow with pnpm caching, dedicated lint and pact jobs, matrix artifacts, and Docker builds that depend on quality gates

## Testing
- Not run (workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d82d83bcdc8332826c787f91221b86