### PR TITLE
Add OPA authorization to documents service

### DIFF
--- a/blp/apps/core-api/src/documents/documents.module.ts
+++ b/blp/apps/core-api/src/documents/documents.module.ts
@@ -3,9 +3,10 @@ import { DocumentsService } from './documents.service';
 import { DocumentsController } from './documents.controller';
 import { EventsModule } from '../events/events.module';
 import { CommonModule } from '../common/common.module';
+import { OpaModule } from '../opa/opa.module';
 
 @Module({
-  imports: [EventsModule, CommonModule],
+  imports: [EventsModule, CommonModule, OpaModule],
   providers: [DocumentsService],
   controllers: [DocumentsController],
   exports: [DocumentsService],

--- a/blp/apps/core-api/test/core-api.spec.ts
+++ b/blp/apps/core-api/test/core-api.spec.ts
@@ -113,7 +113,7 @@ describe('Core API integration', () => {
 
     const loanId = loanRes.body.id;
 
-    const docToken = buildToken(config, tenantA, ['loan:read']);
+    const docToken = buildToken(config, tenantA, ['loan:read', 'document:upload', 'document:list']);
     await request(app.getHttpServer())
       .post(`/loans/${loanId}/documents`)
       .set('Authorization', `Bearer ${docToken}`)


### PR DESCRIPTION
## Summary
- import the OPA module into the documents module so its service can use policy checks
- require document upload and list operations to authorize via OPA actions
- update integration tests to grant the document permissions now required

## Testing
- pnpm --filter core-api test

------
https://chatgpt.com/codex/tasks/task_e_68d834f76bc883329cc59dea7e2fbb90