### PR TITLE
feat: apply Haizel design language to web UI

### DIFF
--- a/blp/apps/web/src/components/ConditionsList.tsx
+++ b/blp/apps/web/src/components/ConditionsList.tsx
@@ -6,11 +6,11 @@ export interface ConditionsListProps {
   filterSeverity?: ConditionSummary['severity'][];
 }
 
-const severityColors: Record<ConditionSummary['severity'], string> = {
-  critical: '#ef4444',
-  high: '#f97316',
-  medium: '#facc15',
-  low: '#22c55e',
+const severityLabels: Record<ConditionSummary['severity'], string> = {
+  critical: 'Critical',
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
 };
 
 export const ConditionsList: React.FC<ConditionsListProps> = ({ conditions, filterSeverity }) => {
@@ -28,10 +28,9 @@ export const ConditionsList: React.FC<ConditionsListProps> = ({ conditions, filt
         {filtered.map((condition) => (
           <li key={condition.code}>
             <span
-              className="conditions-list__severity"
-              style={{ backgroundColor: severityColors[condition.severity] }}
+              className={`conditions-list__severity conditions-list__severity--${condition.severity}`}
             >
-              {condition.severity.toUpperCase()}
+              {severityLabels[condition.severity]}
             </span>
             <div>
               <p className="conditions-list__description">{condition.description}</p>

--- a/blp/apps/web/src/components/DocManifest.tsx
+++ b/blp/apps/web/src/components/DocManifest.tsx
@@ -7,11 +7,15 @@ export interface DocManifestProps {
 }
 
 export const DocManifest: React.FC<DocManifestProps> = ({ status, requiredDocs, onUpload }) => {
+  const statusLabel = status
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+
   return (
     <section className="doc-manifest">
       <header>
         <h3>Document Manifest</h3>
-        <span className={`doc-manifest__status doc-manifest__status--${status}`}>{status}</span>
+        <span className={`doc-manifest__status doc-manifest__status--${status}`}>{statusLabel}</span>
       </header>
       <ul>
         {requiredDocs.map((doc) => (

--- a/blp/apps/web/src/components/WorkflowStepCard.tsx
+++ b/blp/apps/web/src/components/WorkflowStepCard.tsx
@@ -6,13 +6,13 @@ export interface WorkflowStepCardProps {
   onAction?: (step: WorkflowStepContract) => void;
 }
 
-const statusColors: Record<WorkflowStepContract['status'], string> = {
-  pending: '#fbbf24',
-  blocked: '#f87171',
-  in_progress: '#60a5fa',
-  complete: '#34d399',
-  failed: '#ef4444',
-  waived: '#a855f7',
+const statusLabels: Record<WorkflowStepContract['status'], string> = {
+  pending: 'Pending',
+  blocked: 'Blocked',
+  in_progress: 'In progress',
+  complete: 'Complete',
+  failed: 'Failed',
+  waived: 'Waived',
 };
 
 export const WorkflowStepCard: React.FC<WorkflowStepCardProps> = ({ step, onAction }) => {
@@ -20,11 +20,8 @@ export const WorkflowStepCard: React.FC<WorkflowStepCardProps> = ({ step, onActi
     <div className="workflow-step-card">
       <header className="workflow-step-card__header">
         <span className="workflow-step-card__code">{step.code}</span>
-        <span
-          className="workflow-step-card__status"
-          style={{ backgroundColor: statusColors[step.status] }}
-        >
-          {step.status.replace('_', ' ')}
+        <span className={`workflow-step-card__status workflow-step-card__status--${step.status}`}>
+          {statusLabels[step.status]}
         </span>
       </header>
       <div className="workflow-step-card__body">

--- a/blp/apps/web/src/pages/loan/[id].tsx
+++ b/blp/apps/web/src/pages/loan/[id].tsx
@@ -4,6 +4,8 @@ import { WorkflowStepCard } from '../../components/WorkflowStepCard';
 import { ConditionsList } from '../../components/ConditionsList';
 import { DocManifest } from '../../components/DocManifest';
 import { CTCEvaluator } from '../../components/CTCEvaluator';
+
+import '../../styles/global.css';
 import type { WorkflowStepContract, ConditionSummary, ComplianceIssue } from '@haizel/domain';
 
 const mockSteps: WorkflowStepContract[] = [
@@ -80,6 +82,20 @@ const LoanDetailPage: React.FC = () => {
           <button type="button">Upload document</button>
         </div>
       </header>
+      <section className="loan-detail__callouts">
+        <div className="callout callout--action">
+          <h3>Action</h3>
+          <p>Upload income docs to unlock underwriting.</p>
+        </div>
+        <div className="callout callout--assist">
+          <h3>Assist</h3>
+          <p>We’ll highlight exactly what’s missing.</p>
+        </div>
+        <div className="callout callout--heads-up">
+          <h3>Heads up</h3>
+          <p>Appraisal needs verification before closing.</p>
+        </div>
+      </section>
       <section className="loan-detail__workflow">
         <h2>Workflow</h2>
         <div className="loan-detail__workflow-grid">

--- a/blp/apps/web/src/pages/loans/index.tsx
+++ b/blp/apps/web/src/pages/loans/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
+import '../../styles/global.css';
+
 interface LoanRow {
   id: string;
   fileNo: string;
@@ -30,33 +32,38 @@ const LoansPage: React.FC = () => {
   return (
     <main className="loans-page">
       <header className="loans-page__header">
-        <h1>Pipeline</h1>
+        <div>
+          <h1>Pipeline</h1>
+          <p className="loans-page__subtitle">Heads up: Appraisal needs verification.</p>
+        </div>
         <button type="button">Start new loan</button>
       </header>
-      <table className="loans-table">
-        <thead>
-          <tr>
-            <th>File #</th>
-            <th>Borrower</th>
-            <th>Status</th>
-            <th>Owner</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {mockLoans.map((loan) => (
-            <tr key={loan.id}>
-              <td>{loan.fileNo}</td>
-              <td>{loan.borrowerName}</td>
-              <td>{loan.status}</td>
-              <td>{loan.owner}</td>
-              <td>
-                <Link to={`/loan/${loan.id}`}>Open</Link>
-              </td>
+      <div className="table-card">
+        <table className="loans-table">
+          <thead>
+            <tr>
+              <th>File #</th>
+              <th>Borrower</th>
+              <th>Status</th>
+              <th>Owner</th>
+              <th>Actions</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {mockLoans.map((loan) => (
+              <tr key={loan.id}>
+                <td>{loan.fileNo}</td>
+                <td>{loan.borrowerName}</td>
+                <td>{loan.status.replace('_', ' ')}</td>
+                <td>{loan.owner}</td>
+                <td>
+                  <Link to={`/loan/${loan.id}`}>Open loan</Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </main>
   );
 };

--- a/blp/apps/web/src/styles/global.css
+++ b/blp/apps/web/src/styles/global.css
@@ -1,0 +1,569 @@
+:root {
+  --hz-color-primary: #0F2748;
+  --hz-color-primary-hover: #0C1F39;
+  --hz-color-secondary: #2A9CA6;
+  --hz-color-accent: #D7B48A;
+  --hz-color-danger: #D23C6B;
+  --hz-color-neutral-100: #FAFBFD;
+  --hz-color-neutral-300: #C5CCD7;
+  --hz-color-neutral-500: #5A6474;
+  --hz-color-neutral-700: #222A35;
+  --hz-color-neutral-900: #0D121A;
+  --hz-radius-xs: 0.375rem;
+  --hz-radius-md: 0.75rem;
+  --hz-radius-xl: 1rem;
+  --hz-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+  --hz-shadow-md: 0 4px 14px rgba(0, 0, 0, 0.10);
+  --hz-shadow-lg: 0 10px 24px rgba(0, 0, 0, 0.12);
+  --hz-font-sans: Inter, ui-sans-serif, system-ui, Segoe UI, Roboto, Helvetica, Arial, Apple Color Emoji, Segoe UI Emoji;
+  --hz-font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace;
+}
+
+.dark {
+  --hz-surface-bg: var(--hz-color-neutral-900);
+  --hz-surface-card: var(--hz-color-neutral-700);
+  --hz-text: #F8FAFC;
+  --hz-text-sub: var(--hz-color-neutral-300);
+}
+
+:root {
+  --hz-surface-bg: var(--hz-color-neutral-100);
+  --hz-surface-card: #FFFFFF;
+  --hz-text: var(--hz-color-neutral-900);
+  --hz-text-sub: var(--hz-color-neutral-500);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--hz-font-sans);
+  background: var(--hz-surface-bg);
+  color: var(--hz-text);
+}
+
+a {
+  color: var(--hz-color-secondary);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+main {
+  width: min(1100px, 92vw);
+  margin: 2rem auto 4rem;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  color: var(--hz-text);
+  margin: 0;
+}
+
+p {
+  margin: 0;
+  color: var(--hz-text-sub);
+}
+
+button {
+  font: inherit;
+  font-weight: 600;
+  border: none;
+  padding: 0.625rem 1.25rem;
+  border-radius: var(--hz-radius-md);
+  background: var(--hz-color-primary);
+  color: #fff;
+  cursor: pointer;
+  box-shadow: var(--hz-shadow-sm);
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:hover {
+  background: var(--hz-color-primary-hover);
+  box-shadow: var(--hz-shadow-md);
+  transform: translateY(-1px);
+}
+
+button:disabled {
+  background: var(--hz-color-neutral-300);
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.table-card {
+  background: var(--hz-surface-card);
+  border-radius: var(--hz-radius-xl);
+  box-shadow: var(--hz-shadow-lg);
+  overflow: hidden;
+  border: 1px solid rgba(15, 39, 72, 0.04);
+}
+
+.loans-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.loans-page__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.loans-page__header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.loans-page__subtitle {
+  color: var(--hz-text-sub);
+  margin-top: 0.25rem;
+}
+
+.loans-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.loans-table thead {
+  background: var(--hz-color-primary);
+  color: #fff;
+}
+
+.loans-table th,
+.loans-table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  font-size: 0.95rem;
+}
+
+.loans-table tbody tr:nth-child(even) {
+  background: rgba(15, 39, 72, 0.04);
+}
+
+.loans-table tbody tr:hover {
+  background: rgba(42, 156, 166, 0.1);
+}
+
+.loans-table tbody td:last-child a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.loan-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.loan-detail__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.loan-detail__header h1 {
+  font-size: 2.25rem;
+}
+
+.loan-detail__header > div {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.loan-detail__callouts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.callout {
+  padding: 1rem 1.25rem;
+  border-radius: var(--hz-radius-xl);
+  background: var(--hz-surface-card);
+  box-shadow: var(--hz-shadow-md);
+  border: 1px solid rgba(12, 31, 57, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.callout h3 {
+  font-size: 0.95rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--hz-color-primary);
+}
+
+.callout--action {
+  border-left: 4px solid var(--hz-color-secondary);
+}
+
+.callout--assist {
+  border-left: 4px solid var(--hz-color-accent);
+}
+
+.callout--heads-up {
+  border-left: 4px solid var(--hz-color-danger);
+}
+
+.loan-detail__workflow {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.loan-detail__workflow h2 {
+  font-size: 1.5rem;
+}
+
+.loan-detail__workflow-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.workflow-step-card {
+  background: var(--hz-surface-card);
+  border-radius: var(--hz-radius-xl);
+  box-shadow: var(--hz-shadow-md);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border: 1px solid rgba(12, 31, 57, 0.08);
+}
+
+.workflow-step-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.workflow-step-card__code {
+  font-family: var(--hz-font-mono);
+  font-size: 0.85rem;
+  color: var(--hz-color-neutral-500);
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--hz-radius-xs);
+  background: rgba(15, 39, 72, 0.08);
+}
+
+.workflow-step-card__status {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 700;
+  color: #fff;
+}
+
+.workflow-step-card__status--pending {
+  background: var(--hz-color-neutral-500);
+}
+
+.workflow-step-card__status--blocked,
+.workflow-step-card__status--failed {
+  background: var(--hz-color-danger);
+}
+
+.workflow-step-card__status--in_progress {
+  background: var(--hz-color-secondary);
+}
+
+.workflow-step-card__status--complete {
+  background: #2fbf71;
+}
+
+.workflow-step-card__status--waived {
+  background: var(--hz-color-accent);
+  color: var(--hz-color-neutral-900);
+}
+
+.workflow-step-card__body h3 {
+  font-size: 1.125rem;
+}
+
+.workflow-step-card__meta,
+.workflow-step-card__preconditions,
+.workflow-step-card__blocked {
+  color: var(--hz-text-sub);
+  font-size: 0.9rem;
+}
+
+.workflow-step-card__blocked {
+  border-left: 4px solid var(--hz-color-danger);
+  padding-left: 0.5rem;
+}
+
+.workflow-step-card__evidence {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.workflow-step-card__evidence li {
+  background: rgba(42, 156, 166, 0.08);
+  border-radius: var(--hz-radius-xs);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.workflow-step-card__footer {
+  margin-top: auto;
+}
+
+.workflow-step-card__footer button {
+  width: 100%;
+  background: var(--hz-color-secondary);
+}
+
+.workflow-step-card__footer button:hover {
+  background: #24858e;
+}
+
+.loan-detail__panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.conditions-list,
+.doc-manifest,
+.ctc-evaluator {
+  background: var(--hz-surface-card);
+  border-radius: var(--hz-radius-xl);
+  box-shadow: var(--hz-shadow-md);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border: 1px solid rgba(12, 31, 57, 0.08);
+}
+
+.conditions-list header,
+.doc-manifest header,
+.ctc-evaluator header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.conditions-list header h3,
+.doc-manifest header h3,
+.ctc-evaluator header h3 {
+  font-size: 1.1rem;
+}
+
+.conditions-list ul,
+.doc-manifest ul,
+.ctc-evaluator ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.conditions-list li,
+.doc-manifest li,
+.ctc-evaluator ul li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.conditions-list__severity {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #fff;
+  text-transform: uppercase;
+  align-self: center;
+}
+
+.conditions-list__severity--critical {
+  background: var(--hz-color-danger);
+}
+
+.conditions-list__severity--high {
+  background: var(--hz-color-primary);
+}
+
+.conditions-list__severity--medium {
+  background: var(--hz-color-accent);
+  color: var(--hz-color-neutral-900);
+}
+
+.conditions-list__severity--low {
+  background: #2fbf71;
+}
+
+.conditions-list__description {
+  color: var(--hz-text);
+  font-weight: 600;
+}
+
+.conditions-list__status {
+  font-size: 0.85rem;
+}
+
+.doc-manifest__status {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 700;
+  color: #fff;
+}
+
+.doc-manifest__status--in_progress {
+  background: var(--hz-color-secondary);
+}
+
+.doc-manifest__status--complete {
+  background: #2fbf71;
+}
+
+.doc-manifest__status--blocked {
+  background: var(--hz-color-danger);
+}
+
+.doc-manifest__version {
+  font-size: 0.8rem;
+  color: var(--hz-text-sub);
+  margin-left: 0.4rem;
+}
+
+.doc-manifest__actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.doc-manifest__actions span {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.doc-manifest__actions .received {
+  color: #2fbf71;
+}
+
+.doc-manifest__actions .missing {
+  color: var(--hz-color-danger);
+}
+
+.doc-manifest__actions button {
+  background: var(--hz-color-secondary);
+  padding: 0.45rem 0.9rem;
+}
+
+.doc-manifest__actions button:hover {
+  background: #24858e;
+}
+
+.ctc-evaluator__badge {
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.ctc-evaluator__badge--pass {
+  background: #2fbf71;
+  color: var(--hz-color-neutral-900);
+}
+
+.ctc-evaluator__badge--fail {
+  background: var(--hz-color-danger);
+  color: #fff;
+}
+
+.ctc-evaluator__evaluate {
+  background: transparent;
+  color: var(--hz-color-primary);
+  border: 1px solid rgba(15, 39, 72, 0.24);
+  padding: 0.5rem 1rem;
+  border-radius: var(--hz-radius-md);
+  box-shadow: none;
+}
+
+.ctc-evaluator__evaluate:hover {
+  background: rgba(15, 39, 72, 0.08);
+}
+
+.ctc-evaluator__body h4 {
+  font-size: 1rem;
+  color: var(--hz-color-primary);
+}
+
+.ctc-evaluator__body ul li {
+  background: rgba(15, 39, 72, 0.04);
+  border-radius: var(--hz-radius-md);
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.ctc-evaluator__body ul li span {
+  font-weight: 600;
+  color: var(--hz-color-primary);
+}
+
+.ctc-evaluator__body ul li.severity-blocker {
+  border-left: 4px solid var(--hz-color-danger);
+}
+
+.ctc-evaluator__body ul li.severity-major {
+  border-left: 4px solid var(--hz-color-accent);
+}
+
+.ctc-evaluator__body ul li.severity-minor {
+  border-left: 4px solid var(--hz-color-secondary);
+}
+
+.ctc-evaluator__body ul li .remediation {
+  font-size: 0.85rem;
+}
+
+@media (max-width: 768px) {
+  main {
+    margin-top: 1.5rem;
+  }
+
+  .loan-detail__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .loan-detail__header > div {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .loan-detail__header button {
+    flex: 1 1 140px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a global stylesheet that defines Haizel design tokens, surfaces, and responsive layout treatments
- restyle the loan list and detail pages with warm callouts and updated copy that reflects the product voice
- align workflow, conditions, and document manifest components to the new color system and badge styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d844ecb1a48332a19bb69c0a78e6a9