### PR TITLE
Update GoDaddy config for haizeltechnology.com

### DIFF
--- a/infra/dns/godaddy_upsert/config.json
+++ b/infra/dns/godaddy_upsert/config.json
@@ -1,5 +1,5 @@
 {
-  "domain": "hazeltechnology.com",
+  "domain": "haizeltechnology.com",
   "ttl": 600,
   "records": {
     "@": {


### PR DESCRIPTION
## Summary
- point the GoDaddy DNS configuration at haizeltechnology.com while keeping existing records intact

## Testing
- make dns.dryrun *(fails: outbound HTTPS requests are blocked in this environment)*
- make dns.apply *(fails: outbound HTTPS requests are blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d934f2aa108332bea57ca8ee8bd3f3