### PR TITLE
Automate core API tests against Postgres

### DIFF
--- a/blp/README.md
+++ b/blp/README.md
@@ -26,3 +26,20 @@ The generated structure follows the architecture described in the specification,
    - Worker service: background worker connected to Temporal
 
 Stop the stack with `docker compose -f infra/docker-compose.dev.yml down`.
+
+## Running Core API integration tests
+
+The Core API test suite now runs against a disposable PostgreSQL instance so that Prisma-backed services execute against the shared schema. Use the helper script to provision the database, apply migrations, run the Jest suite, and tear everything down automatically:
+
+```bash
+pnpm test:core-api
+```
+
+The script performs the following steps:
+
+1. Launches a PostgreSQL 15 container defined in `infra/docker-compose.test.yml` and exports `DATABASE_URL` for downstream commands.
+2. Waits for the database to become ready, then executes `pnpm --filter db exec prisma migrate deploy` so all tables required by `PrismaService` are available.
+3. Runs `pnpm --filter core-api test`.
+4. Shuts down the Docker Compose stack and removes the ephemeral volume.
+
+The compose project name, port, and database URL can be customised via the `PROJECT_NAME`, `CORE_API_TEST_DB_PORT`, and `DATABASE_URL` environment variables respectively.

--- a/blp/db/package.json
+++ b/blp/db/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@haizel/db",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "prisma": "prisma",
+    "migrate:deploy": "prisma migrate deploy",
+    "generate": "prisma generate"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.16.0"
+  },
+  "devDependencies": {
+    "prisma": "^5.16.0"
+  },
+  "prisma": {
+    "schema": "prisma/schema.prisma"
+  }
+}

--- a/blp/infra/docker-compose.test.yml
+++ b/blp/infra/docker-compose.test.yml
@@ -1,0 +1,22 @@
+version: '3.9'
+
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: blp
+      POSTGRES_PASSWORD: blp
+      POSTGRES_DB: blp
+    ports:
+      - "${CORE_API_TEST_DB_PORT:-55432}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U blp"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:
+    driver: local

--- a/blp/package.json
+++ b/blp/package.json
@@ -11,6 +11,7 @@
     "lint": "pnpm -r lint",
     "test": "pnpm -r test",
     "test:rls": "bash db/tests/run_rls_checks.sh",
+    "test:core-api": "./scripts/test-core-api.sh",
     "dev": "docker compose -f infra/docker-compose.dev.yml up --build"
   }
 }

--- a/blp/pnpm-lock.yaml
+++ b/blp/pnpm-lock.yaml
@@ -477,6 +477,16 @@ importers:
         specifier: ^1.4.0
         version: 1.6.1(@types/node@20.19.17)(jsdom@24.1.3)(terser@5.44.0)
 
+  db:
+    dependencies:
+      '@prisma/client':
+        specifier: ^5.16.0
+        version: 5.22.0(prisma@5.22.0)
+    devDependencies:
+      prisma:
+        specifier: ^5.16.0
+        version: 5.22.0
+
   packages/domain: {}
 
 packages:
@@ -1393,6 +1403,30 @@ packages:
     resolution: {integrity: sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@prisma/client@5.22.0':
+    resolution: {integrity: sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==}
+    engines: {node: '>=16.13'}
+    peerDependencies:
+      prisma: '*'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+
+  '@prisma/debug@5.22.0':
+    resolution: {integrity: sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==}
+
+  '@prisma/engines-version@5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2':
+    resolution: {integrity: sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==}
+
+  '@prisma/engines@5.22.0':
+    resolution: {integrity: sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==}
+
+  '@prisma/fetch-engine@5.22.0':
+    resolution: {integrity: sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==}
+
+  '@prisma/get-platform@5.22.0':
+    resolution: {integrity: sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -4620,6 +4654,11 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  prisma@5.22.0:
+    resolution: {integrity: sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==}
+    engines: {node: '>=16.13'}
+    hasBin: true
+
   process-warning@3.0.0:
     resolution: {integrity: sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==}
 
@@ -6828,6 +6867,31 @@ snapshots:
   '@playwright/test@1.55.1':
     dependencies:
       playwright: 1.55.1
+
+  '@prisma/client@5.22.0(prisma@5.22.0)':
+    optionalDependencies:
+      prisma: 5.22.0
+
+  '@prisma/debug@5.22.0': {}
+
+  '@prisma/engines-version@5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2': {}
+
+  '@prisma/engines@5.22.0':
+    dependencies:
+      '@prisma/debug': 5.22.0
+      '@prisma/engines-version': 5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2
+      '@prisma/fetch-engine': 5.22.0
+      '@prisma/get-platform': 5.22.0
+
+  '@prisma/fetch-engine@5.22.0':
+    dependencies:
+      '@prisma/debug': 5.22.0
+      '@prisma/engines-version': 5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2
+      '@prisma/get-platform': 5.22.0
+
+  '@prisma/get-platform@5.22.0':
+    dependencies:
+      '@prisma/debug': 5.22.0
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -10419,6 +10483,12 @@ snapshots:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.3.1
+
+  prisma@5.22.0:
+    dependencies:
+      '@prisma/engines': 5.22.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   process-warning@3.0.0: {}
 

--- a/blp/pnpm-workspace.yaml
+++ b/blp/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ packages:
   - "apps/connectors/*"
   - "libs/*"
   - "packages/*"
+  - "db"

--- a/blp/scripts/test-core-api.sh
+++ b/blp/scripts/test-core-api.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+COMPOSE_FILE=${COMPOSE_FILE:-"$ROOT_DIR/infra/docker-compose.test.yml"}
+PROJECT_NAME=${PROJECT_NAME:-blp_core_api_tests}
+export DATABASE_URL=${DATABASE_URL:-postgresql://blp:blp@127.0.0.1:${CORE_API_TEST_DB_PORT:-55432}/blp}
+
+cd "$ROOT_DIR"
+
+cleanup() {
+  docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" down -v >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" up -d postgres
+
+ATTEMPTS=0
+until docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" exec -T postgres pg_isready -U blp >/dev/null 2>&1; do
+  ATTEMPTS=$((ATTEMPTS + 1))
+  if [ "$ATTEMPTS" -ge 60 ]; then
+    echo "PostgreSQL did not become ready in time" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" exec -T postgres psql -U blp -d blp -c 'SELECT 1;' >/dev/null
+
+pnpm --filter db exec prisma migrate deploy
+pnpm --filter core-api test


### PR DESCRIPTION
## Summary
- add a disposable PostgreSQL Compose file and helper script that exports DATABASE_URL, runs migrations, executes the Core API tests, and cleans up
- introduce an @haizel/db workspace so pnpm --filter db exec prisma migrate deploy is available for the shared schema
- document the new integration-test workflow and expose it via pnpm test:core-api for CI usage

## Testing
- pnpm test:core-api *(fails: docker: command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d937bf57788332bac95d1e967170e7