### PR TITLE
Add deployment execution report

### DIFF
--- a/docs/deployment-report.md
+++ b/docs/deployment-report.md
@@ -1,0 +1,15 @@
+# Deployment Execution Report
+
+## Build Output
+- Ran `pnpm --filter web-app-react build` from the repository root.
+- Production bundle generated under `blp/apps/web-app-react/dist/`.
+
+## Outstanding Hosting Tasks
+The remaining deployment steps (provisioning hosting, uploading assets, SPA routing configuration, and TLS/redirect validation) require access to external infrastructure providers. These actions could not be performed in the current offline workspace.
+
+## Recommended Next Actions
+1. Provision hosting (e.g., AWS CloudFront/S3 or ALB-backed service) that supports both `haizeltechnology.com` and `www.haizeltechnology.com` aliases.
+2. Upload/sync `blp/apps/web-app-react/dist/` to the chosen origin and configure the SPA fallback to `index.html` for unmatched routes.
+3. Enable TLS termination, enforce HTTP→HTTPS redirects, and verify host header handling for both apex and www domains.
+
+Document generated on Sun Sep 28 13:35:01 UTC 2025.


### PR DESCRIPTION
## Summary
- document the successful local build of the web-app-react production bundle
- record hosting tasks that remain outstanding because they require external infrastructure access

## Testing
- pnpm --filter web-app-react build

------
https://chatgpt.com/codex/tasks/task_e_68d9390f37dc833290a3ff2fdc21d191