### PR TITLE
Add DigitalOcean app specification for core API

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,0 +1,36 @@
+spec:
+  name: haizel-app
+  services:
+    - name: core-api
+      environment_slug: node-js
+      instance_count: 1
+      instance_size_slug: basic-xxs
+      source_dir: blp
+      build_command: corepack enable && pnpm install --frozen-lockfile && pnpm --filter core-api build
+      run_command: pnpm --filter core-api exec node dist/main.js
+      http_port: 3000
+      routes:
+        - path: /
+      envs:
+        - key: DATABASE_URL
+          type: SECRET
+          scope: RUN_TIME
+        - key: AUTH0_DOMAIN
+          type: GENERAL
+          scope: RUN_TIME
+        - key: AUTH0_CLIENT_ID
+          type: SECRET
+          scope: RUN_TIME
+        - key: AUTH0_CLIENT_SECRET
+          type: SECRET
+          scope: RUN_TIME
+        - key: AUTH0_AUDIENCE
+          type: GENERAL
+          scope: RUN_TIME
+        - key: AUTH0_ISSUER_BASE_URL
+          type: GENERAL
+          scope: RUN_TIME
+        - key: PORT
+          value: "3000"
+          type: GENERAL
+          scope: RUN_TIME


### PR DESCRIPTION
## Summary
- add a DigitalOcean App Platform spec describing how to build and run the core API from the blp source directory
- configure service routing on port 3000 with required Auth0 and database environment variables

## Testing
- not run (configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68d93d2a16748332b3c93285d3a53fd1