### PR TITLE
chore: configure core api process for DO deployment

### DIFF
--- a/blp/Procfile
+++ b/blp/Procfile
@@ -1,0 +1,1 @@
+web: pnpm --filter @haizel/core-api run start

--- a/blp/apps/core-api/package.json
+++ b/blp/apps/core-api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "core-api",
+  "name": "@haizel/core-api",
   "version": "0.1.0",
   "type": "module",
   "main": "dist/main.js",

--- a/blp/apps/core-api/src/main.ts
+++ b/blp/apps/core-api/src/main.ts
@@ -48,8 +48,11 @@ async function bootstrap() {
   };
   process.once('SIGINT', shutdown);
   process.once('SIGTERM', shutdown);
-  const port = Number.parseInt(process.env.PORT ?? '', 10) || 8080;
-  await app.listen(port);
+  const port = Number.parseInt(process.env.PORT ?? '8080', 10);
+  const host = '0.0.0.0';
+  await app.listen(port, host);
+  // eslint-disable-next-line no-console
+  console.log(`Core API listening on http://${host}:${port}`);
 }
 
 bootstrap().catch(async (error) => {


### PR DESCRIPTION
## Summary
- add a Procfile so the platform starts the scoped core API package
- scope the core API package name to align with the Procfile filter
- bind the Nest server to the injected host/port and log the binding

## Testing
- pnpm --filter @haizel/core-api run build *(fails: dotenv CLI not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d97292990c8332ada8dcb0a086f5e9