### PR TITLE
Remove invalid user document relation

### DIFF
--- a/blp/db/prisma/schema.prisma
+++ b/blp/db/prisma/schema.prisma
@@ -124,7 +124,6 @@ model User {
   createdAt         DateTime       @default(dbgenerated("now()")) @map("created_at") @db.Timestamptz(6)
   updatedAt         DateTime       @default(dbgenerated("now()")) @map("updated_at") @db.Timestamptz(6)
   memberships       TenantUser[]
-  uploadedDocuments LoanDocument[] @relation("UserUploadedDocuments")
 
   @@map("users")
 }


### PR DESCRIPTION
## Summary
- remove the unused User.uploadedDocuments relation so the schema only exposes the TenantUser-based uploader link

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9787cfe70833293e5917e14b68db1