### PR TITLE
chore: regenerate pnpm lockfile with pnpm@9.12

### DIFF
--- a/blp/pnpm-lock.yaml
+++ b/blp/pnpm-lock.yaml
@@ -1501,6 +1501,7 @@ packages:
   '@pact-foundation/pact-core@14.3.8':
     resolution: {integrity: sha512-CG1DhuA/ROEgmAaj9DaFnSZ8fpLNoiSgK5QyM9WkFsx5gFoRHBS2g4Gw+s7ZDp9NkoxbMuZ3HCCicXoVPCGUwg==}
     engines: {node: '>=16'}
+    cpu: [x64, ia32, arm64]
     os: [darwin, linux, win32]
     hasBin: true
 


### PR DESCRIPTION
## Summary
- regenerate the workspace lockfile using pnpm@9.12.0 so metadata stays current

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d97900977c8332a2d7fadf79af33db