### PR TITLE
feat: prepare @haizel/api for consumption

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -10,7 +10,10 @@ services:
       pnpm --version
       pnpm run lock:check
       pnpm install -w --frozen-lockfile
-      pnpm -r run build
+      pnpm --filter @haizel/db run generate
+      pnpm --filter @haizel/observability run build
+      pnpm --filter @haizel/api run build
+      pnpm --filter core-api run build
     run_command: pnpm --filter core-api exec node dist/main.js
     environment_slug: node-js
     envs:

--- a/blp/apps/api/package.json
+++ b/blp/apps/api/package.json
@@ -2,36 +2,34 @@
   "name": "@haizel/api",
   "version": "0.1.0",
   "private": true,
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./src/index.ts",
-      "default": "./src/index.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./observability": {
-      "import": "./src/observability/index.ts",
-      "default": "./src/observability/index.ts"
+      "types": "./dist/observability/index.d.ts",
+      "import": "./dist/observability/index.js",
+      "default": "./dist/observability/index.js"
     }
   },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rimraf dist"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "rimraf": "^5.0.0"
+  },
   "dependencies": {
-    "@nestjs/common": "^10.0.0",
-    "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/context-async-hooks": "^1.18.0",
-    "@opentelemetry/core": "^1.18.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "^0.51.1",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.51.1",
-    "@opentelemetry/instrumentation": "^0.51.1",
-    "@opentelemetry/instrumentation-express": "^0.40.1",
-    "@opentelemetry/instrumentation-http": "^0.51.1",
-    "@opentelemetry/instrumentation-nestjs-core": "^0.37.0",
-    "@opentelemetry/propagator-b3": "^1.18.0",
-    "@opentelemetry/resources": "^1.18.0",
-    "@opentelemetry/sdk-metrics": "^1.18.0",
-    "@opentelemetry/sdk-node": "^0.51.1",
-    "@opentelemetry/semantic-conventions": "^1.18.0",
-    "rxjs": "^7.8.1",
-    "express": "^4.18.2",
-    "@types/express": "^4.17.21"
+    "@haizel/domain": "workspace:*",
+    "@haizel/observability": "workspace:*",
+    "@temporalio/workflow": "^1.13.0"
   }
 }

--- a/blp/apps/api/src/documents/manifest.ts
+++ b/blp/apps/api/src/documents/manifest.ts
@@ -105,7 +105,8 @@ export class DocumentManifestService {
         ];
 
     const received = nextDocuments.filter((doc) => doc.required && doc.received).length;
-    const status = received === manifest.required ? 'complete' : received > 0 ? 'in_progress' : 'pending';
+    const status: ManifestSummary['status'] =
+      received === manifest.required ? 'complete' : received > 0 ? 'in_progress' : 'pending';
 
     const next: ManifestSummary = {
       ...manifest,
@@ -125,8 +126,9 @@ export class DocumentManifestService {
       return null;
     }
     const received = manifest.documents.filter((doc) => doc.required && doc.received).length;
-    const status = received === manifest.required ? 'complete' : received > 0 ? 'in_progress' : 'pending';
-    const next = {
+    const status: ManifestSummary['status'] =
+      received === manifest.required ? 'complete' : received > 0 ? 'in_progress' : 'pending';
+    const next: ManifestSummary = {
       ...manifest,
       received,
       status,

--- a/blp/apps/api/src/index.ts
+++ b/blp/apps/api/src/index.ts
@@ -9,3 +9,4 @@ export * from './providers/mi';
 export * from './providers/aus';
 export * from './providers/esign';
 export * from './providers/title';
+export * from './observability';

--- a/blp/apps/api/src/observability/index.ts
+++ b/blp/apps/api/src/observability/index.ts
@@ -1,0 +1,1 @@
+export * from '@haizel/observability';

--- a/blp/apps/api/src/providers/amc.ts
+++ b/blp/apps/api/src/providers/amc.ts
@@ -44,7 +44,7 @@ export class RealAppraisalManagementCompanyProvider implements AppraisalManageme
   constructor(private readonly client: VendorHttpClient) {}
 
   async order(ctx: ProviderContext, request: AppraisalOrderRequest): Promise<AppraisalOrderResponse> {
-    const { data } = await this.client.call<ExternalAppraisalOrderRequest, AppraisalOrderResponse>(
+    const { data } = await this.client.call<AppraisalOrderRequest, ExternalAppraisalOrderRequest, AppraisalOrderResponse>(
       {
         ctx,
         vendor: 'amc',

--- a/blp/apps/api/src/providers/assets.ts
+++ b/blp/apps/api/src/providers/assets.ts
@@ -59,7 +59,11 @@ export class RealAssetVerificationProvider implements AssetVerificationProvider 
       throw error;
     }
 
-    const { data } = await this.client.call<ExternalAssetRequest, AssetVerificationProviderResponse>(
+    const { data } = await this.client.call<
+      AssetVerificationProviderRequest,
+      ExternalAssetRequest,
+      AssetVerificationProviderResponse
+    >(
       {
         ctx,
         vendor: 'assets',

--- a/blp/apps/api/src/providers/aus.ts
+++ b/blp/apps/api/src/providers/aus.ts
@@ -45,7 +45,11 @@ export class RealAutomatedUnderwritingProvider implements AutomatedUnderwritingP
   constructor(private readonly client: VendorHttpClient) {}
 
   async submit(ctx: ProviderContext, request: AUSSubmitRequest): Promise<AUSSubmitResponse> {
-    const { data } = await this.client.call<ExternalAusSubmitRequest, AUSSubmitResponse>(
+    const { data } = await this.client.call<
+      AUSSubmitRequest,
+      ExternalAusSubmitRequest,
+      AUSSubmitResponse
+    >(
       {
         ctx,
         vendor: 'aus',

--- a/blp/apps/api/src/providers/base.ts
+++ b/blp/apps/api/src/providers/base.ts
@@ -133,12 +133,12 @@ export interface HttpResponse {
 
 export type HttpCaller = (request: HttpRequest) => Promise<HttpResponse>;
 
-export interface VendorHttpCallOptions<TRequest> {
+export interface VendorHttpCallOptions<TPayload, TRequest = TPayload> {
   ctx: ProviderContext;
   vendor: VendorKind;
   operation: string;
   idempotencyKey: string;
-  request: TRequest;
+  request: TPayload;
   path: string;
   method?: string;
   redactFields?: string[];
@@ -254,10 +254,10 @@ export class VendorHttpClient {
     private readonly breaker: CircuitBreaker = new CircuitBreaker(),
   ) {}
 
-  async call<TRequest, TResponse = unknown>(
-    options: VendorHttpCallOptions<TRequest>,
+  async call<TPayload, TRequest = TPayload, TResponse = unknown>(
+    options: VendorHttpCallOptions<TPayload, TRequest>,
     transform: {
-      request?: (payload: TRequest, credential: VendorCredential) => unknown;
+      request?: (payload: TPayload, credential: VendorCredential) => TRequest;
       response?: (payload: unknown, response: HttpResponse) => TResponse;
       onSuccess?: (payload: TResponse, raw: unknown) => Promise<void> | void;
       successEvent?: { name: VendorEventName; payload: (data: TResponse) => Record<string, unknown> };

--- a/blp/apps/api/src/providers/credit.ts
+++ b/blp/apps/api/src/providers/credit.ts
@@ -75,7 +75,11 @@ export class RealCreditProvider implements CreditProvider {
     }
 
     const idempotencyKey = `credit:tri-merge:${ctx.loanId}:${input.consentToken}`;
-    const { data } = await this.client.call<ExternalCreditRequest, CreditProviderResponse>(
+    const { data } = await this.client.call<
+      CreditProviderRequest,
+      SerializedCreditRequest,
+      CreditProviderResponse
+    >(
       {
         ctx,
         vendor: 'credit',
@@ -115,11 +119,15 @@ export class RealCreditProvider implements CreditProvider {
 }
 
 interface ExternalCreditRequest {
-  correlationId: string;
   borrower: CreditProviderRequest['borrower'];
   coBorrower?: CreditProviderRequest['borrower'];
   consentToken: string;
-  options?: CreditProviderRequest['options'];
+  options?: Record<string, unknown>;
+}
+
+interface SerializedCreditRequest {
+  correlationId: string;
+  payload: ExternalCreditRequest;
 }
 
 interface ExternalCreditResponse {
@@ -128,7 +136,7 @@ interface ExternalCreditResponse {
   rawVendorResponse: unknown;
 }
 
-function serializeRequest(ctx: ProviderContext, input: ExternalCreditRequest) {
+function serializeRequest(ctx: ProviderContext, input: ExternalCreditRequest): SerializedCreditRequest {
   return {
     correlationId: ctx.correlationId,
     payload: input,

--- a/blp/apps/api/src/providers/esign.ts
+++ b/blp/apps/api/src/providers/esign.ts
@@ -53,7 +53,11 @@ export class RealESignProvider implements ESignProvider {
   constructor(private readonly client: VendorHttpClient) {}
 
   async generate(ctx: ProviderContext, request: ESignGenerateRequest): Promise<ESignEnvelope> {
-    const { data } = await this.client.call<ExternalESignGenerateRequest, ESignEnvelope>(
+    const { data } = await this.client.call<
+      ESignGenerateRequest,
+      ExternalESignGenerateRequest,
+      ESignEnvelope
+    >(
       {
         ctx,
         vendor: 'esign',
@@ -87,7 +91,11 @@ export class RealESignProvider implements ESignProvider {
   }
 
   async send(ctx: ProviderContext, envelopeId: string): Promise<ESignEnvelope> {
-    const { data } = await this.client.call<ExternalESignSendRequest, ESignEnvelope>(
+    const { data } = await this.client.call<
+      { envelopeId: string },
+      ExternalESignSendRequest,
+      ESignEnvelope
+    >(
       {
         ctx,
         vendor: 'esign',

--- a/blp/apps/api/src/providers/flood.ts
+++ b/blp/apps/api/src/providers/flood.ts
@@ -24,7 +24,7 @@ export class RealFloodProvider implements FloodProvider {
   constructor(private readonly client: VendorHttpClient) {}
 
   async order(ctx: ProviderContext): Promise<FloodOrderResponse> {
-    const { data } = await this.client.call<ExternalFloodRequest, FloodOrderResponse>(
+    const { data } = await this.client.call<ExternalFloodRequest, ExternalFloodRequest, FloodOrderResponse>(
       {
         ctx,
         vendor: 'flood',

--- a/blp/apps/api/src/providers/incomeEmployment.ts
+++ b/blp/apps/api/src/providers/incomeEmployment.ts
@@ -56,7 +56,11 @@ export class RealIncomeEmploymentProvider implements IncomeEmploymentProvider {
       throw error;
     }
 
-    const { data } = await this.client.call<ExternalIncomeEmploymentRequest, IncomeEmploymentProviderResponse>(
+    const { data } = await this.client.call<
+      IncomeEmploymentProviderRequest,
+      ExternalIncomeEmploymentRequest,
+      IncomeEmploymentProviderResponse
+    >(
       {
         ctx,
         vendor: 'income_employment',

--- a/blp/apps/api/src/providers/mi.ts
+++ b/blp/apps/api/src/providers/mi.ts
@@ -40,7 +40,11 @@ export class RealMortgageInsuranceProvider implements MortgageInsuranceProvider 
   constructor(private readonly client: VendorHttpClient) {}
 
   async quote(ctx: ProviderContext, request: MortgageInsuranceQuoteRequest): Promise<MortgageInsuranceQuoteResponse> {
-    const { data } = await this.client.call<ExternalMiQuoteRequest, MortgageInsuranceQuoteResponse>(
+    const { data } = await this.client.call<
+      MortgageInsuranceQuoteRequest,
+      ExternalMiQuoteRequest,
+      MortgageInsuranceQuoteResponse
+    >(
       {
         ctx,
         vendor: 'mi',

--- a/blp/apps/api/src/providers/title.ts
+++ b/blp/apps/api/src/providers/title.ts
@@ -56,7 +56,11 @@ export class RealTitleProvider implements TitleProvider {
   constructor(private readonly client: VendorHttpClient) {}
 
   async open(ctx: ProviderContext, request: TitleOpenRequest): Promise<TitleOrderResponse> {
-    const { data } = await this.client.call<ExternalTitleOpenRequest, TitleOrderResponse>(
+    const { data } = await this.client.call<
+      TitleOpenRequest,
+      ExternalTitleOpenRequest,
+      TitleOrderResponse
+    >(
       {
         ctx,
         vendor: 'title',
@@ -89,7 +93,11 @@ export class RealTitleProvider implements TitleProvider {
   }
 
   async recordCurative(ctx: ProviderContext, orderId: string, tasks: TitleCurativeTask[]): Promise<TitleOrderResponse> {
-    const { data } = await this.client.call<ExternalTitleCurativeRequest, TitleOrderResponse>(
+    const { data } = await this.client.call<
+      { orderId: string; tasks: TitleCurativeTask[] },
+      ExternalTitleCurativeRequest,
+      TitleOrderResponse
+    >(
       {
         ctx,
         vendor: 'title',

--- a/blp/apps/api/src/types/domain.d.ts
+++ b/blp/apps/api/src/types/domain.d.ts
@@ -1,0 +1,71 @@
+declare module '@haizel/domain' {
+  export type StepCode =
+    | 'CREDIT'
+    | 'INCOME_EMPLOYMENT'
+    | 'ASSETS'
+    | 'APPRAISAL'
+    | 'TITLE'
+    | 'FLOOD'
+    | 'MI'
+    | 'DISCLOSURES'
+    | 'AUS'
+    | 'CLOSING';
+
+  export type WorkflowStepStatus =
+    | 'pending'
+    | 'blocked'
+    | 'in_progress'
+    | 'complete'
+    | 'failed'
+    | 'waived';
+
+  export interface WorkflowEvidenceRef {
+    docId?: string;
+    vendorCallId?: string;
+    note?: string;
+  }
+
+  export interface WorkflowTimestamps {
+    createdAt: string;
+    startedAt?: string;
+    completedAt?: string;
+  }
+
+  export interface WorkflowStepContract {
+    id: string;
+    loanId: string;
+    code: StepCode;
+    title: string;
+    required: boolean;
+    ownerRole: 'LO' | 'PROCESSOR' | 'CLOSER' | 'TITLE' | 'SYSTEM';
+    status: WorkflowStepStatus;
+    preconditions: string[];
+    dueAt?: string;
+    slaSeconds?: number;
+    blockedReason?: string;
+    evidenceRefs: WorkflowEvidenceRef[];
+    timestamps: WorkflowTimestamps;
+  }
+
+  export interface ConditionSummary {
+    code: string;
+    description: string;
+    severity: 'critical' | 'high' | 'medium' | 'low';
+    status: 'open' | 'waived' | 'met';
+  }
+
+  export interface ComplianceIssue {
+    code: string;
+    severity: 'info' | 'warning' | 'blocker';
+    message: string;
+    remediation?: string;
+  }
+
+  export type ComplianceStage =
+    | 'PRE_FLIGHT'
+    | 'PRE_VENDOR_CALL'
+    | 'PRE_DISCLOSURE'
+    | 'AUS'
+    | 'CTC'
+    | 'CLOSING';
+}

--- a/blp/apps/api/src/types/temporal-workflow.d.ts
+++ b/blp/apps/api/src/types/temporal-workflow.d.ts
@@ -1,0 +1,12 @@
+declare module '@temporalio/workflow' {
+  export interface WorkflowInfo {
+    workflowId: string;
+  }
+
+  export function condition(predicate: () => boolean | Promise<boolean>): Promise<void>;
+  export function setHandler(signal: string, handler: (...args: unknown[]) => void): void;
+  export function workflowInfo(): WorkflowInfo;
+  export function proxyActivities<TActivityTypes>(
+    options: Record<string, unknown>,
+  ): TActivityTypes;
+}

--- a/blp/apps/api/src/workflows/haizelPipeline.workflows.ts
+++ b/blp/apps/api/src/workflows/haizelPipeline.workflows.ts
@@ -118,7 +118,7 @@ async function propertyAndRiskStage(ctx: StepExecutionContext): Promise<void> {
 }
 
 async function ausStage(ctx: StepExecutionContext): Promise<void> {
-  const result = await executeStep('AUS', activities.submitAus, ctx);
+  const result = await executeStep<AUSResult>('AUS', activities.submitAus, ctx);
   if (result?.ausDecision === 'REFER_WITH_CAUTION') {
     await waitForUnblock();
   }
@@ -150,7 +150,7 @@ async function closingStage(ctx: StepExecutionContext): Promise<void> {
   await activities.closeLoan({ ...ctx, stepCode: 'CLOSING' });
 }
 
-async function executeStep<T extends StepResult | AUSResult>(
+async function executeStep<T extends StepResult>(
   stepCode: StepCode,
   activity: (input: StepExecutionContext) => Promise<T>,
   baseCtx: StepExecutionContext,

--- a/blp/apps/api/tsconfig.json
+++ b/blp/apps/api/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "module": "CommonJS",
+    "target": "ES2020",
+    "moduleResolution": "Node",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a dedicated tsconfig and package metadata so @haizel/api builds to dist outputs
- adjust vendor client generics, request payloads, and add local type shims so the library compiles cleanly
- ensure the DigitalOcean build pipeline builds shared packages before core-api

## Testing
- pnpm --filter @haizel/api run build

------
https://chatgpt.com/codex/tasks/task_e_68d9796f87708332a7fe8cd02be9cd57